### PR TITLE
Client-side sorting: Allow a comma to separate date/time items

### DIFF
--- a/js/i18n/grid.locale-en.js
+++ b/js/i18n/grid.locale-en.js
@@ -87,9 +87,9 @@ $.jgrid = {
 		model : "Length of colNames <> colModel!"
 	},
 	formatter : {
-		integer : {thousandsSeparator: ",", defaultValue: '0'},
-		number : {decimalSeparator:".", thousandsSeparator: ",", decimalPlaces: 2, defaultValue: '0.00'},
-		currency : {decimalSeparator:".", thousandsSeparator: ",", decimalPlaces: 2, prefix: "", suffix:"", defaultValue: '0.00'},
+		integer : {thousandsSeparator: " ", defaultValue: '0'},
+		number : {decimalSeparator:".", thousandsSeparator: " ", decimalPlaces: 2, defaultValue: '0.00'},
+		currency : {decimalSeparator:".", thousandsSeparator: " ", decimalPlaces: 2, prefix: "", suffix:"", defaultValue: '0.00'},
 		date : {
 			dayNames:   [
 				"Sun", "Mon", "Tue", "Wed", "Thr", "Fri", "Sat",


### PR DESCRIPTION
Tony,

During a discussion here ( http://stackoverflow.com/questions/4074358/jqgrid-datetime-sorting/4079773#4079773 ) it was noted that you made a fix to allow a comma to separate date/time items for server-side sorting of date/times. See these changes to DateFormat:

http://github.com/tonytomov/jqGrid/commit/ed6eec0d1a522bf6e0f8ec6f15f2b22105249586

However the fix was never applied for client-side sorting. This pull request is for that (simple) change, in the chance you may find it useful. It's a simple two-liner, but since the SO discussion brought it up I thought it would be worthwhile to bring it to your attention.

Thanks,

Justin
