### PR TITLE
Add a boolean option named "percentWidth" 

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -598,6 +598,7 @@ $.fn.jqGrid = function( pin ) {
 			colModel: [],
 			rowList: [],
 			colNames: [],
+            percentWidth: false,
 			sortorder: "asc",
 			sortname: "",
 			datatype: "xml",
@@ -2087,11 +2088,20 @@ $.fn.jqGrid = function( pin ) {
 		}
 		if(ts.p.footerrow) { tfoot += "</tr></tbody></table>"; }
 		firstr += "</tr>";
+
+
+		var colgroupHtml = '<colgroup>';
+		for (var j = 0, cln = this.p.colNames.length; j < cln; j++) {
+			colgroupHtml += '<col ' + 'class="jqgrid-col' + (j + 1) + '"'  + '>';
+		}
+		colgroupHtml += '</colgroup>';
+		$(this).append(colgroupHtml);
+
 		tbody = document.createElement("tbody");
 		this.appendChild(tbody);
 		$(this).addClass('ui-jqgrid-btable').append(firstr);
 		firstr = null;
-		var hTable = $("<table class='ui-jqgrid-htable' style='width:"+ts.p.tblwidth+"px' role='grid' aria-labelledby='gbox_"+this.id+"' cellspacing='0' cellpadding='0' border='0'></table>").append(thead),
+		var hTable = $("<table class='ui-jqgrid-htable' style='width:"+ts.p.tblwidth+"px' role='grid' aria-labelledby='gbox_"+this.id+"' cellspacing='0' cellpadding='0' border='0'>" + colgroupHtml + "</table>").append(thead),
 		hg = (ts.p.caption && ts.p.hiddengrid===true) ? true : false,
 		hb = $("<div class='ui-jqgrid-hbox" + (dir=="rtl" ? "-rtl" : "" )+"'></div>");
 		thead = null;
@@ -2349,6 +2359,23 @@ $.fn.jqGrid = function( pin ) {
 		$(window).unload(function () {
 			ts = null;
 		});
+
+		function cleanStyleForPercent (gridID) {
+			var theaders = $('.ui-jqgrid-labels').find('th[id*='  + gridID + ']'),
+					cols = $('#'  + gridID).find('tbody .jqgfirstrow').find('td');
+
+			$('.ui-jqgrid-bdiv,.ui-jqgrid-hdiv,.ui-jqgrid-view,.ui-jqgrid,.ui-jqgrid-hbox,.ui-jqgrid-htable').
+				removeAttr('style').addClass('cwidth');
+			$('#'  + gridID).css('width', '100%');
+			$('.cwidth').css('width', '100%');
+			theaders.removeAttr('style');
+			cols.removeAttr('style');
+		}
+
+		if (ts.p.percentWidth) {
+			cleanStyleForPercent(ts.p.id);
+		}
+        
 	});
 };
 $.jgrid.extend({


### PR DESCRIPTION
Edited file grid.base.js.
Add a boolean option named "percentWidth" whose default is false, but when the percentWidth is true, it will allow using percent widths on each column of the grid.

Submitted on behalf of Globalquest Solutions Inc.
http://globalquestinc.com/ 
