### PR TITLE
Fixed error with wrong initialized variable

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -115,7 +115,7 @@ $.extend($.jgrid,{
 		return sid.replace(/([\.\:\[\]])/g,"\\$1");
 	},
 	getAccessor : function(obj, expr) {
-		var ret,p,prm, i;
+		var ret,p,prm = [], i;
 		if( typeof expr === 'function') { return expr(obj); }
 		ret = obj[expr];
 		if(ret===undefined) {


### PR DESCRIPTION
prm is used as array later on so it should be initialized as such to avoid error "prm is undefined" in some cases
