### PR TITLE
Naming a column 'length' results in an error

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1327,7 +1327,7 @@ $.fn.jqGrid = function( pin ) {
 			}
 		},
 		addLocalData = function() {
-			var st, fndsort=false, cmtypes=[], grtypes=[], grindexes=[], srcformat, sorttype, newformat;
+			var st, fndsort=false, cmtypes={}, grtypes=[], grindexes=[], srcformat, sorttype, newformat;
 			if(!$.isArray(ts.p.data)) {
 				return;
 			}


### PR DESCRIPTION
# Information
### Affects

Current release and presumably earlier releases
### Browsers

Tested in IE 7, IE 8, Firefox 3.6, Safari 5 and Chrome 8
### Component

Base jqGrid functionality
# Steps to Reproduce

Create a simple table with a column model declaring one of the column names to be `length`. For example:

```
var mydata = [ { id: "1", length: "20 seconds" } ];

jQuery("#grid").jqGrid({
    data: mydata,
    datatype: "local",
    height: 'auto',
    rowNum: 1,
    colNames: ['Film', 'Length'],
    colModel: [ { name: 'id', index: 'id', width: 60, sorttype: "int" },
                { name: 'length', index: 'length', width: 100, editable: true } ],
});
```

Upon loading a page with this Javascript (and the necessary jqGrid files and an element like `<table id='grid'>`) an uncaught RangeError is thrown:

```
Uncaught RangeError: Invalid array length
  $.fn.jqGrid.each.addLocalData.compareFnMap.eq     grid.base.js:1351
  c.extend.each                                     jquery.min.js:30
  $.fn.jqGrid.each.addLocalData                     grid.base.js:1332
  $.fn.jqGrid.each.populate                         grid.base.js:1628
  $.fn.jqGrid                                       grid.base.js:2343
  c.extend.each                                     jquery.min.js:30
  c.fn.c.each                                       jquery.min.js:24
  $.fn.jqGrid                                       grid.base.js:585
  (anonymous function)
```
# Cause

`grid.base.js` is attempting to index into a normal `Array` using an associative-array semantic with the column name as the attempted key. Because `Array` also has a method named `length`, this fails and is interpreted as an attempt to assign to the length of an array.
# Solution

Change the array in question to an `Object`. See pull request.
