### PR TITLE
customelement issue when names/ids contain CSS notation chars

### DIFF
--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -374,7 +374,7 @@ $.jgrid.extend({
 						$.each($t.p.colModel, function(i,n){
 							if(this.name == nm && this.editoptions && $.isFunction(this.editoptions.custom_value)) {
 								try {
-									postdata[nm] = this.editoptions.custom_value($("#"+nm.replace(/(:|\.)/g, '\\$1'),"#"+frmtb),'get');
+									postdata[nm] = this.editoptions.custom_value($("#"+$.jgrid.jqID(nm),"#"+frmtb),'get');
 									if (postdata[nm] === undefined) { throw "e1"; }
 								} catch (e) {
 									if (e=="e1") { $.jgrid.info_dialog(jQuery.jgrid.errors.errcap,"function 'custom_value' "+$.jgrid.edit.msg.novalue,jQuery.jgrid.edit.bClose);}


### PR DESCRIPTION
I'm using jqGrid in my ASP.NET  MVC application and the form elements contain "." characters to facilitate use of MVC built-in model binding (<input type="text" name="Address.Line1"...) and noticed this presents a problem when using customelement edittypes because of line 377 in grid.formedit.js, getFormData() function:

```
                                postdata[nm] = this.editoptions.custom_value($("#" + nm, "#" + frmtb), 'get');
```

Changing to this fixes the issue:

```
                                postdata[nm] = this.editoptions.custom_value($("#" + nm.replace(/(:|\.)/g, '\\$1'), "#" + frmtb), 'get');
```

jQuery's site mentions this issue/solution in their FAQ area - http://docs.jquery.com/Frequently_Asked_Questions#How_do_I_select_an_element_by_an_ID_that_has_characters_used_in_CSS_notation.3F
