### PR TITLE
add New Event : onClickGroup

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -616,6 +616,7 @@ $.fn.jqGrid = function( pin ) {
 			selrow: null,
 			beforeSelectRow: null,
 			onSelectRow: null,
+			onClickGroup: null,
 			onSortCol: null,
 			ondblClickRow: null,
 			onRightClickRow: null,

--- a/js/grid.grouping.js
+++ b/js/grid.grouping.js
@@ -96,10 +96,13 @@ $.jgrid.extend({
 					$("#"+hid).nextUntil("#"+uid+String(num)).hide();
 				}
 				$("#"+hid+" span").removeClass(minus).addClass(plus);
+				collapsed = true;
 			} else {
 				$("#"+hid).nextUntil("#"+uid+String(num)).show();
 				$("#"+hid+" span").removeClass(plus).addClass(minus);
+				collapsed = false;
 			}
+			if( $t.p.onClickGroup) { $t.p.onClickGroup.call($t, hid , collapsed); }
 		});
 		return false;
 	},


### PR DESCRIPTION
This event fires after clicking group (to expand or collapse group). it has 2 parameters, group id (string) and collapsed (boolean). 'groupid' is a combination of grid id plus 'ghead_' plus the current count number in the grid view. 'collapsed' is current group's collapse status.

we use onClickGroup event to keep collapsed state. When reloading the grid (not the whole page, just the grid) the current collapsed state of the groups is lost. we've been thinking about storing those parameters in a localStorage. 

please visit this link https://github.com/byakugie/clockingit/commit/bc56e361b44cd57dd41d52e4279119ac6aae2952 to see how we are using 'onClickGroup' event in Jobsworth project.
