### PR TITLE
tableToGrid: verify if there are checkboxes or radioboxes only in the first column

### DIFF
--- a/js/grid.tbltogrid.js
+++ b/js/grid.tbltogrid.js
@@ -13,8 +13,8 @@ jQuery(selector).each(function() {
 	var w = jQuery(this).width();
 
 	// Text whether we have single or multi select
-	var inputCheckbox = jQuery('input[type=checkbox]:first', jQuery(this));
-	var inputRadio = jQuery('input[type=radio]:first', jQuery(this));
+	var inputCheckbox = jQuery('tr td:first-child input[type=checkbox]:first', jQuery(this));
+	var inputRadio = jQuery('tr td:first-child input[type=radio]:first', jQuery(this));
 	var selectMultiple = inputCheckbox.length > 0;
 	var selectSingle = !selectMultiple && inputRadio.length > 0;
 	var selectable = selectMultiple || selectSingle;


### PR DESCRIPTION
The tableToGrid function was supposed to look for checkboxes and/or radioboxes only in the first column, but the selector being used is looking for the first checkbox and/or radiobox in the table, not just in the first column.

This patch fixes the selector to only look for checkboxes and/or radioboxes in the first column.
