### PR TITLE
Fix for issue #118, The search is not performed if the column's name != index

### DIFF
--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -148,7 +148,7 @@ $.jgrid.extend({
 					switch (this.stype) {
 						case 'select' :
 							so  = (this.searchoptions && this.searchoptions.sopt) ? this.searchoptions.sopt[0] : 'eq';
-							v = $("#gs_"+$.jgrid.jqID(nm),$t.grid.hDiv).val();
+							v = $("#gs_"+$.jgrid.jqID(this.name),$t.grid.hDiv).val();
 							if(v) {
 								sdata[nm] = v;
 								sopt[nm] = so;
@@ -161,7 +161,7 @@ $.jgrid.extend({
 							break;
 						case 'text':
 							so  = (this.searchoptions && this.searchoptions.sopt) ? this.searchoptions.sopt[0] : p.defaultSearch;
-							v = $("#gs_"+$.jgrid.jqID(nm), $t.grid.hDiv).val();
+							v = $("#gs_"+$.jgrid.jqID(this.name), $t.grid.hDiv).val();
 							if(v) {
 								sdata[nm] = v;
 								sopt[nm] = so;


### PR DESCRIPTION
The error is only in incorrect index/Name selection in filter toolbar.
