### PR TITLE
simple null check before calling nextSibling

### DIFF
--- a/js/grid.grouping.js
+++ b/js/grid.grouping.js
@@ -95,7 +95,7 @@ $.jgrid.extend({
 			minus = grp.minusicon,
 			plus = grp.plusicon,
 			tar = $("#"+hid),
-			r = tar[0].nextSibling,
+			r = tar.length ? tar[0].nextSibling : null,
 			tarspan = $("#"+hid+" span."+"tree-wrap-"+$t.p.direction),
 			collapsed = false;
 			if( tarspan.hasClass(minus) ) {


### PR DESCRIPTION
checking for existence of underlying element before referencing it (there was an error in IE7/8)
