### PR TITLE
Fixed multiselect checkboxes behavior

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2267,12 +2267,10 @@ $.fn.jqGrid = function( pin ) {
 					} else {
 						$(ts).jqGrid("setSelection",ptr[0].id,true);
 					}
-				} else {
-					if(e[ts.p.multikey]) {
+				} else { if (e[ts.p.multikey]) {
 						$(ts).jqGrid("setSelection",ptr[0].id,true);
 					} else if(ts.p.multiselect && scb) {
-						scb = $("#jqg_"+$.jgrid.jqID(ts.p.id)+"_"+ptr[0].id).attr("checked");
-						$("#jqg_"+$.jgrid.jqID(ts.p.id)+"_"+ptr[0].id).attr("checked",!scb);
+            $(ts).jqGrid("setSelection",ptr[0].id,true);
 					}
 				}
 				if($.isFunction(ts.p.onCellSelect)) {


### PR DESCRIPTION
When using multiselect:true and multikey:'ctrlKey' the checkboxes for each row behave exactly the same as the top checkbox - clicking any of them will select/deselect all rows. 

This patch fixes them so click on a checkbox selects/deselects specific row only