### PR TITLE
Data with commas causes wrong select option to be choosen during form editing

### DIFF
--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -540,7 +540,7 @@ $.jgrid.extend({
 								var opv = tmp.split(",");
 								opv = $.map(opv,function(n){return $.trim(n);});
 								$("#"+nm+" option","#"+fmid).each(function(j){
-									if (!cm[i].editoptions.multiple && (opv[0] == $.trim($(this).text()) || opv[0] == $.trim($(this).val())) ){
+									if (!cm[i].editoptions.multiple && (tmp == $.trim($(this).text()) || opv[0] == $.trim($(this).val())) ){
 										this.selected= true;
 									} else if (cm[i].editoptions.multiple){
 										if(  $.inArray($.trim($(this).text()), opv ) > -1 || $.inArray($.trim($(this).val()), opv ) > -1  ){


### PR DESCRIPTION
During form editing, if your data has commas within it ("Hello,World"), the correct select option never happens because of the tmp.split(","). This only occurs the second (and subsequent) time you open the form for editing.
