### PR TITLE
Allow for cancelling changes in beforeSaveCell handler

### DIFF
--- a/js/grid.celledit.js
+++ b/js/grid.celledit.js
@@ -178,6 +178,9 @@ $.jgrid.extend({
 						var vv = $t.p.beforeSaveCell.call($t, $t.rows[iRow].id,nm, v, iRow,iCol);
 						if (vv) {v = vv; v2=vv;}
 					}
+				}
+				// Compare again in case the beforSaveCell handler returned the initial value
+				if (v2 !== $t.p.savedRow[fr].v){
 					var cv = $.jgrid.checkValues(v,iCol,$t);
 					if(cv[0] === true) {
 						var addpost = {};


### PR DESCRIPTION
This change allows you to cancel changes before they are saved by returning the initial value, stored in $t.p.savedRow[0].v
