### PR TITLE
Incorrect select option chosen when using form editing

### DIFF
--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -913,7 +913,7 @@ $.jgrid.extend({
 				bt += "<tr style='display:none' class='binfo'><td class='bottominfo' colspan='2'>"+rp_ge[$t.p.id].bottominfo+"</td></tr>";
 				bt += "</tbody></table>";
 				if(maxRows >  0) {
-					var sd=[];
+					var sd=[], div={};
 					$.each($(tbl)[0].rows,function(i,r){
 						sd[i] = r;
 					});
@@ -923,8 +923,9 @@ $.jgrid.extend({
 						return 0;
 					});
 					$.each(sd, function(index, row) {
-						$('tbody',tbl).append(row);
+						div.html += row;
 					});
+					$('tbody',tbl).append(div.html);
 				}
 				p.gbox = "#gbox_"+gID;
 				var cle = false;


### PR DESCRIPTION
During form editing, if your data has commas within it ("Hello,World"), then the form edit will never choose the correct select option because of the tmp.split(","). This only occurs the second (and subsequent) times you open the form for editing.
