### PR TITLE
Override request type for inline edit

### DIFF
--- a/js/grid.inlinedit.js
+++ b/js/grid.inlinedit.js
@@ -20,7 +20,8 @@ $.jgrid.extend({
 			"aftersavefunc" : aftersavefunc || null,
 			"errorfunc": errorfunc || null,
 			"afterrestorefunc" : afterrestorefunc|| null,
-			"restoreAfterError" : true
+			"restoreAfterError" : true,
+			"mtype" : "POST"
 		},
 		args = $.makeArray(arguments).slice(1), o;
 
@@ -101,7 +102,8 @@ $.jgrid.extend({
 			"aftersavefunc" : aftersavefunc || null,
 			"errorfunc": errorfunc || null,
 			"afterrestorefunc" : afterrestorefunc|| null,
-			"restoreAfterError" : true
+			"restoreAfterError" : true,
+			"mtype" : "POST"
 		},
 		args = $.makeArray(arguments).slice(1), o;
 
@@ -222,7 +224,7 @@ $.jgrid.extend({
 				$.ajax($.extend({
 					url:o.url,
 					data: $.isFunction($t.p.serializeRowData) ? $t.p.serializeRowData.call($t, tmp3) : tmp3,
-					type: "POST",
+					type: o.mtype,
 					async : false, //?!?
 					complete: function(res,stat){
 						$("#lui_"+$t.p.id).hide();


### PR DESCRIPTION
I needed to override the request sent to the server for inline edits to use a PUT instead of a POST.

This change allows specifying the `mtype` param for `editRow` and `saveRow` as it's done for `editGridRow` and `delGridRow`. For example,

``` javascript
$('#grid_id').jqGrid('editRow', row_id, { keys: true, url: action, mtype: 'PUT' })
```
