### PR TITLE
Negated null check that was preevnting sorting working correctly.

### DIFF
--- a/js/grid.treegrid.js
+++ b/js/grid.treegrid.js
@@ -233,7 +233,7 @@ $.jgrid.extend({
 				case 'adjacency' :
 					var parent_id = $t.p.treeReader.parent_id_field;
 					$($t.p.data).each(function(i){
-						if(this[parent_id] === null || String(this[parent_id]).toLowerCase() == "null") {
+						if(!(this[parent_id] === null || String(this[parent_id]).toLowerCase() == "null")) {
 							result.push(this);
 						}
 					});


### PR DESCRIPTION
Negated null check that was preventing sorting working correctly. 

See http://stackoverflow.com/questions/7330572/sorting-of-jqgrid-v4-1-2-treegrid-not-working-with-ajacency-model 
and
http://www.trirand.com/blog/?page_id=393/bugs/sorting-of-jqgrid-v4-1-2-treegrid-not-working-with-ajacency-model/

UPDATE: I may just have to pass in null as parent rather than 0 (zero)
