### PR TITLE
Call endReq only after all AJAX calls have completed

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1697,11 +1697,11 @@ $.fn.jqGrid = function( pin ) {
 							if (pvis) { ts.grid.populateVisible(); }
 							if( ts.p.loadonce || ts.p.treeGrid) {ts.p.datatype = "local";}
 							data=null;
-							endReq();
+							if (npage === 1) { endReq(); }
 						},
 						error:function(xhr,st,err){
 							if($.isFunction(ts.p.loadError)) { ts.p.loadError.call(ts,xhr,st,err); }
-							endReq();
+							if (npage === 1) { endReq(); }
 							xhr=null;
 						},
 						beforeSend: function(xhr){


### PR DESCRIPTION
This fixes a problem with virtual scrolling where multiple AJAX requests are made (e.g., when the scroll bar is moved to the bottom of a large scrollable region). By not calling endReq until after the last AJAX request completes, we prevent results being loaded out of order and the pager from showing bad range values (e.g., -19 - 120 of 135).
