### PR TITLE
ReloadNode() for TreeGrids

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2601,6 +2601,14 @@ $.jgrid.extend({
 							if($t.p.treeGrid===true && nm == $t.p.ExpandColumn) {
 								res[nm] = $.jgrid.htmlDecode($("span:first",this).html());
 							} else {
+								if($t.p.colModel[i].key != undefined && $t.p.colModel[i].key == true)
+								{
+									try {
+										res["_" + nm + "_"] = $.unformat(this,{rowId:ind.id, colModel:$t.p.colModel[i]},i);
+									} catch (e){
+										res["_" + nm + "_"] = $.jgrid.htmlDecode($(this).html());
+									}
+								}
 								try {
 									res[nm] = $.unformat(this,{rowId:ind.id, colModel:$t.p.colModel[i]},i);
 								} catch (e){


### PR DESCRIPTION
We created a function to reload a specified node from a remote location, if needed. In our application, we do some heavy database work with jqGrid as a front end, and periodically need to show the results without reloading the entire grid at once. It is based off of expandNode and accepts the same arguments, but deletes all the child nodes of that node using another custom function delChildNodes, and then sends the request to get the newly updated list of child nodes which it will then display. This patch also includes a small change to getRowData, as attempting to use it on our side would always result in errors, as it would not set the _id_ field in the JSON return.

We found this useful, as we use jqGrid to emulate a file structure. We don't know how useful it will be to you, but we figured we would send a commit request in case you thought it could be useful.