### PR TITLE
Fix for allowing html tables as cell content

### DIFF
--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -518,7 +518,7 @@ $.jgrid.extend({
 				}
 				var tre = $(obj).jqGrid("getInd",rowid,true);
 				if(!tre) { return; }
-				$('td',tre).each( function(i) {
+				$('td[role="gridcell"]',tre).each( function(i) {
 					nm = cm[i].name;
 					// hidden fields are included in the form
 					if ( nm !== 'cb' && nm !== 'subgrid' && nm !== 'rn' && cm[i].editable===true) {


### PR DESCRIPTION
In function fillData replaced:

$('td',tre).each( function(i) {
with:
$('td[role="gridcell"]',tre).each( function(i) {

so that html tables can be used as cell content.

E.g.
{
"total": "1",
"page": "1",
"records": "1",
"rows" : [
{"id" :"-100", "cell":
 [
 "-100","-100","<table><tr><td>dsdsdsd</td></tr></table>","-100","-100","-100","-100"
 ]
}
]}

Otherwise, second click on edit breaks.
