### PR TITLE
Corrected error on ie when a row is selected

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2551,7 +2551,7 @@ $.jgrid.extend({
 			if(selection === undefined) { return; }
 			onsr = onsr === false ? false : true;
 			pt=$t.rows.namedItem(selection+"");
-			if(!pt || pt.className.indexOf( 'ui-state-disabled' ) > -1 ) { return; }
+			if(!pt || !pt.className || pt.className.indexOf( 'ui-state-disabled' ) > -1 ) { return; }
 			function scrGrid(iR){
 				var ch = $($t.grid.bDiv)[0].clientHeight,
 				st = $($t.grid.bDiv)[0].scrollTop,


### PR DESCRIPTION
Hello,

I propose to correct the error on IE when a row is selected:
"className" is null or not an object".

The grid I load from a static table. The table have rich cells.
