### PR TITLE
fixed treegrid bug for id's of 0

### DIFF
--- a/js/grid.treegrid.js
+++ b/js/grid.treegrid.js
@@ -559,7 +559,7 @@ $.jgrid.extend({
 			loaded = $t.p.treeReader.loaded,
 			method, parentindex, parentdata, parentlevel, i, len, max=0, rowind = parentid, leaf, maxright;
 
-			if ( !nodeid ) {
+			if ( typeof nodeid === 'undefined' || nodeid === null ) {
 				i = $t.p.data.length-1;
 				if(	i>= 0 ) {
 					while(i>=0){max = Math.max(max, parseInt($t.p.data[i][$t.p.localReader.id],10)); i--;}


### PR DESCRIPTION
I noticed that when adding rows to a treegrid, if the first ID was `0`, it was converted to `"1"`.  This caused bugs when adding a subsequent tree node whose parent was `0`.  My initialization code:

```
$series = $("#series").jqGrid({
    treeGrid: true,
    treeGridModel: 'adjacency',
    datatype: 'local',
    treedatatype: 'local',
    colModel:[
        {name:'id', label:'ID', index:'id', width:55, key:true},
        {name:'name', label:'Name', index:'name asc, invdate', width:100},
    ],
    jsonReader: {
        repeatitems: false,
        root: function (obj) { return obj; },
        page: function (obj) { return 1; },
        total: function (obj) { return 1; },
        records: function (obj) { return obj.length; }
    },
    pager: '#series_pager',
    sortname: 'id',
    sortorder: "desc"
});
```

And the `data` object:

```
{
    children: [
        {
            id: 0,
            name: 'node 0',
            children: [
                {
                    id: 1,
                    name: 'node 1',
                }
            ]
        }
    ]
}
```

And finally, the calls that caused the error:

```
$series.jqGrid('addChildNode', data.data.children[0].id, null, data.data.children[0]);
$series.jqGrid('addChildNode', data.data.children[0].children[0].id, data.data.children[0].id, data.data.children[0].children[0])
```
