### PR TITLE
Event bubble up to click row but e.target has already gone

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2329,7 +2329,7 @@ $.fn.jqGrid = function( pin ) {
 		$(ts).before(grid.hDiv).click(function(e) {
 			td = e.target;
 			ptr = $(td,ts.rows).closest("tr.jqgrow");
-			if($(ptr).length === 0 || ptr[0].className.indexOf( 'ui-state-disabled' ) > -1 || $(td,ts).closest("table.ui-jqgrid-btable")[0].id.replace("_frozen","") !== ts.id ) {
+			if($(ptr).length === 0 || ptr[0].className.indexOf( 'ui-state-disabled' ) > -1 || ($(td,ts).closest("table.ui-jqgrid-btable").attr('id') || '').replace("_frozen","") !== ts.id ) {
 				return this;
 			}
 			var scb = $(td).hasClass("cbox"),


### PR DESCRIPTION
Don't know if this situation is specific to me or not. My case:

1) Opened a jquery-ui dialog, with grid inside 
2) grid initialized and loaded with data, with one of the cell format as a hyperlink 
3) the link has a delegation, which will clear grid data

``` javascript
   $("#list").delegate("a", "click", function(){
        $("#target").val($(this).data('xxx')); 
        $("list").clearGridData();
        $("dialog").dialog("close");
   });
```

4) When `a` is clicked, the event bubble up to `grid.hdiv`, which has a click event to handle selection. In that event, it try to locate `table.ui-jqgrid-btable`:

``` javascript
$(td,ts).closest("table.ui-jqgrid-btable")[0].id.replace("_frozen","")
```

but `table.ui-jqgrid-btable` would not be found as `clearGridData` already "detached" the rows from the table, and thus exception occur. 

Normally by `return false`  in `delegate` should solve the problem but I think the grid itself should also avoid this.
