### PR TITLE
$.jqrid.realType(null) is 'Object' in IE < 8

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -48,7 +48,9 @@ $.extend($.jgrid,{
 		}
 	},
 	realType : function (arg) {
-		return Object.prototype.toString.call(arg).slice(8, -1);
+		 return arg === null ? "Null"
+			: arg == null ? "Undefined"
+			: Object.prototype.toString.call(arg).slice(8, -1);
 	},
 	stripPref : function (pref, id) {
 		var obj = this.realType( pref );


### PR DESCRIPTION
Happen when I call saveRow like

``` javascript
grid.saveRow(rowid, null, this.editurl, [], function(){
     //do things after save
}, this));
```

In IE7, the function does not work. Debugging found that the `aftersavefunc` is not assigned

``` javascript
saveRow : function(rowid, successfunc, url, extraparam, aftersavefunc,errorfunc, afterrestorefunc) {
    // Compatible mode old versions
    var args = $.makeArray(arguments).slice(1), o = {};

    if( $.jgrid.realType(args[0]) === "Object" ) {
        o = args[0];
    } else {
        if ($.isFunction(successfunc)) { o.successfunc = successfunc; }
        if (typeof url !== "undefined") { o.url = url; }
        if (typeof extraparam !== "undefined") { o.extraparam = extraparam; }
        if ($.isFunction(aftersavefunc)) { o.aftersavefunc = aftersavefunc; }
        if ($.isFunction(errorfunc)) { o.errorfunc = errorfunc; }
        if ($.isFunction(afterrestorefunc)) { o.afterrestorefunc = afterrestorefunc; }
    }
    //...
}
```

Tested on IE7 that `$.jgrid.realType(null)` returns `Object`, where it is `Null` in chrome.

I followed the discussion under this post http://javascriptweblog.wordpress.com/2011/08/08/fixing-the-javascript-typeof-operator/ and integrate this gist https://gist.github.com/1131946 to check null, but as there is no 'global' parameter I can refer to so I removed it.

I checked all the occurrences `$.jgrid.realType`, it only check for `String`, `Number` and `Object` now.
