### PR TITLE
Extending filterToolbar to allow passing a user defined function that is used to filter/match rows. 

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -588,6 +588,16 @@ $.extend($.jgrid,{
 			self._resetNegate();
 			return self;
 		};
+		this.ca=function(f, v, xxx, functionName) {
+			if(_useProperties){
+				self._append(functionName + "(" + self._getStr('jQuery.jgrid.getAccessor(this,\''+f+'\')')+',\''+self._toStr(v)+'\', this, \''+f+'\')===true');
+			}else{
+				self._append(functionName + "(" + self._getStr('this')+',\''+self._toStr(v)+'\', this, \''+f+'\')===true');
+			}
+			self._setCommand(self.ca,f);
+			self._resetNegate();
+			return self;
+		};
 		this.groupBy=function(by,dir,type, datefmt){
 			if(!self._hasData()){
 				return null;
@@ -1478,8 +1488,8 @@ $.fn.jqGrid = function( pin ) {
 				'ni':function(queryObj,op) {return op === "OR" ? queryObj.orNot().equals : queryObj.andNot().equals;},
 				'in':function(queryObj,op) {return queryObj.equals;},
 				'nu':function(queryObj,op) {return queryObj.isNull;},
-				'nn':function(queryObj,op) {return op === "OR" ? queryObj.orNot().isNull : queryObj.andNot().isNull;}
-
+				'nn':function(queryObj,op) {return op === "OR" ? queryObj.orNot().isNull : queryObj.andNot().isNull;},
+				'ca':function(queryObj,op) {return queryObj.ca;}
 			},
 			query = $.jgrid.from(ts.p.data);
 			if (ts.p.ignoreCase) { query = query.ignoreCase(); }
@@ -1521,7 +1531,7 @@ $.fn.jqGrid = function( pin ) {
 								if(s > 0 && opr && opr === "OR") {
 									query = query.or();
 								}
-								query = compareFnMap[rule.op](query, opr)(rule.field, rule.data, cmtypes[rule.field]);
+								query = compareFnMap[rule.op](query, opr)(rule.field, rule.data, cmtypes[rule.field], rule.mfn);
 							}
 							s++;
 						}

--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -145,10 +145,13 @@ $.jgrid.extend({
 			var $t = this;
 			if(this.ftoolbar) { return; }
 			var triggerToolbar = function() {
-				var sdata={}, j=0, v, nm, sopt={},so;
+				var sdata={}, j=0, v, nm, sopt={},so,mfn={};
 				$.each($t.p.colModel,function(i,n){
 					nm = this.index || this.name;
 					so  = (this.searchoptions && this.searchoptions.sopt) ? this.searchoptions.sopt[0] : this.stype=='select'?  'eq' : p.defaultSearch;
+					if (this.searchoptions && this.searchoptions.mfn) {
+						mfn[nm] = this.searchoptions.mfn;
+					}
 					v = $("#gs_"+$.jgrid.jqID(this.name), (this.frozen===true && $t.p.frozenColumns === true) ?  $t.grid.fhDiv : $t.grid.hDiv).val();
 					if(v) {
 						sdata[nm] = v;
@@ -167,6 +170,7 @@ $.jgrid.extend({
 					$.each(sdata,function(i,n){
 						if (gi > 0) {ruleGroup += ",";}
 						ruleGroup += "{\"field\":\"" + i + "\",";
+						ruleGroup += "\"mfn\":\"" + mfn[i] + "\",";
 						ruleGroup += "\"op\":\"" + sopt[i] + "\",";
 						n+="";
 						ruleGroup += "\"data\":\"" + n.replace(/\\/g,'\\\\').replace(/\"/g,'\\"') + "\"}";


### PR DESCRIPTION
Extending filterToolbar to allow passing a user defined function that is used to filter/match rows.

Typical usage:
function regExMatch(cellValue,filterValue,row,fieldName) {
    var re = new RegExp(filterValue);
    return re.test(row[fieldName]);
}

---- jqgrid initializations ----
colModel:[
  {name:'dates',index:'dates', searchoptions:{ sopt:["ca"], mfn:"regExMatch" }},
