### PR TITLE
escaping pager and toppager with $.jgrid.jqID

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -137,7 +137,7 @@ $.extend($.jgrid,{
 		return new Date(tsp.y, tsp.m, tsp.d, tsp.h, tsp.i, tsp.s, tsp.u);
 	},
 	jqID : function(sid){
-		return String(sid).replace(/[!"#$%&'()*+,.\/:;<=>?@\[\\\]\^`{|}~]/g,"\\$&");
+		return String(sid).replace(/[!"#$%&'()*+,.\/: ;<=>?@\[\\\]\^`{|}~]/g,"\\$&");
 	},
 	guid : 1,
 	uidPref: 'jqg',


### PR DESCRIPTION
I tried to fix all places where `$.jgrid.jqID` need be used with `pager` and `toppager`.

First of all one should decide in which format the p.pager and p.toppager should hold the information.
In the suggested changes both ts.p.pager and ts.p.toppager will be used as **selectors** of pagers like `"#pager"` or `"#list_toppager"`. So it will be saved in _escaped_ (by $.jgrid.jqID) form.

The next change is: we will call `setPager` fuction with _id_ as parameter and not as _selector_
to be able to generate HTML fragmants based on the id easier. To get id from selector we will use
`$(ts.p.toppager).attr("id")`. So the call of `setPager` fuction will be

```
setPager($(ts.p.toppager).attr("id"),'_t');
```

or

```
setPager($(ts.p.pager).attr("id"),'');
```

After the changes one can easy to modify the code of `setPager` to escape ids if needed.

The **input** parameter of `p.pager` can be
     a) the `id` of the pager (like `"pager"`) - it should be escaped.
     b) the id _selector_ of the pager (like `"#pager"`) - **it have to be already escaped**.
     c) the DOM or jQuery object which represent the pager. We will get `id` attribute of it and save as
        `ts.p.pager = "#" + $.jgrid.jqID($(ts.p.pager).attr("id"));`
     d) wrong parameter - we change it to empty string `""`.

In the way we can normalize all (or the most) cases of pager usage.

I hope I included no bugs in the suggested changes :-)

Best regards
Oleg

Signed-off-by: Dr. Oleg Kiriljuk oleg.kiriljuk@ok-soft-gmbh.com
