### PR TITLE
fix performance problem of TreeGrid during expanging or collapsing of nodes having large number of children

### DIFF
--- a/js/grid.treegrid.js
+++ b/js/grid.treegrid.js
@@ -190,10 +190,11 @@ $.jgrid.extend({
 			if(!$t.grid || !$t.p.treeGrid) {return;}
 			var childern = $($t).jqGrid("getNodeChildren",record),
 			//if ($($t).jqGrid("isVisibleNode",record)) {
-			expanded = $t.p.treeReader.expanded_field;
+			expanded = $t.p.treeReader.expanded_field,
+			rows = $t.rows;
 			$(childern).each(function(i){
 				var id  = $.jgrid.getAccessor(this,$t.p.localReader.id);
-				$("#"+$.jgrid.jqID(id),$t.grid.bDiv).css("display","");
+				$(rows.namedItem(id)).css("display","");
 				if(this[expanded]) {
 					$($t).jqGrid("expandRow",this);
 				}
@@ -206,10 +207,11 @@ $.jgrid.extend({
 			var $t = this;
 			if(!$t.grid || !$t.p.treeGrid) {return;}
 			var childern = $($t).jqGrid("getNodeChildren",record),
-			expanded = $t.p.treeReader.expanded_field;
+			expanded = $t.p.treeReader.expanded_field,
+			rows = $t.rows;
 			$(childern).each(function(i){
 				var id  = $.jgrid.getAccessor(this,$t.p.localReader.id);
-				$("#"+$.jgrid.jqID(id),$t.grid.bDiv).css("display","none");
+				$(rows.namedItem(id)).css("display","none");
 				if(this[expanded]){
 					$($t).jqGrid("collapseRow",this);
 				}


### PR DESCRIPTION
Hello Tony,

I described the problem in [the bug fix](http://www.trirand.com/blog/?page_id=393/bugs/slow-performance-of-treegrid-on-collapse-or-expand/#p26091). In the suggested code I improved my original suggestion by usage of `$($t.rows.namedItem(id))` instead of previously suggested `$("#"+$.jgrid.jqID(id))`. The current jqGrid code uses `$("#"+$.jgrid.jqID(id),$t.grid.bDiv)` which is very slow because no index can be used for the searching.

[The demo](http://www.ok-soft-gmbh.com/jqGrid/TreeGrid2.html) demonstrate the working of the fixed version which is much better as [the demo](http://www.ok-soft-gmbh.com/jqGrid/treegrid0.html) which uses jqGrid 4.3.1.

Best regards
Oleg

Signed-off-by: Dr. Oleg Kiriljuk oleg.kiriljuk@ok-soft-gmbh.com
