### PR TITLE
Prevent activation of default button when pressing Enter to submit changes

### DIFF
--- a/js/grid.celledit.js
+++ b/js/grid.celledit.js
@@ -91,7 +91,11 @@ $.jgrid.extend({
 							$($t).jqGrid("restoreCell",iRow,iCol);
 						}
 					} //ESC
-					if (e.keyCode === 13) {$($t).jqGrid("saveCell",iRow,iCol);}//Enter
+					if (e.keyCode === 13) {
+						$($t).jqGrid("saveCell",iRow,iCol);}
+						// Prevent default action
+						return false;
+					} //Enter
 					if (e.keyCode === 9)  {
 						if(!$t.grid.hDiv.loading ) {
 							if (e.shiftKey) {$($t).jqGrid("prevCell",iRow,iCol);} //Shift TAb


### PR DESCRIPTION
The default action must be cancelled while saving changes in the grid. If not, this could activate the default button of the form where the grid is located.
