### PR TITLE
Fix for addParams.addRowParams not being used in a inline add & save

### DIFF
--- a/js/grid.inlinedit.js
+++ b/js/grid.inlinedit.js
@@ -505,9 +505,6 @@ $.jgrid.extend({
 							var saveParams;
 							var opers = $t.p.prmNames,
 							oper = opers.oper;
-							// if(!o.editParams.extraparam) {
-							//	o.editParams.extraparam = {};
-							//}
 							if($("#"+$.jgrid.jqID(sr), "#"+gID ).hasClass("jqgrid-new-row")) {
 								if(!o.addParams.addRowParams.extraparam) {
 									o.addParams.addRowParams.extraparam = {};
@@ -521,7 +518,6 @@ $.jgrid.extend({
 								o.editParams.extraparam[oper] = opers.editoper;
 								saveParams = o.editParams;
 							}
-//							if( $($t).jqGrid('saveRow', sr, o.editParams) ) {
 							if( $($t).jqGrid('saveRow', sr, saveParams) ) {
 								$($t).jqGrid('showAddEditButtons');
 							}


### PR DESCRIPTION
When inline add is used to add a record and saved, the options provided in addParams.addRowParams are not being used. Instead editParams is always used. This causes a problem when we use different options for saving a new and an existing row.

This has been fixed. 
