### PR TITLE
Some fixes for grid.locale-en.js and grid.locale-de.js

### DIFF
--- a/js/i18n/grid.locale-de.js
+++ b/js/i18n/grid.locale-de.js
@@ -9,6 +9,11 @@
  * Andreas Flack
  * http://www.contentcontrol-berlin.de
  *
+ * Updated for jQuery 4.4
+ * Oleg Kiriljuk oleg.kiriljuk@ok-soft-gmbh.com
+ * the format corresponds now the format from
+ * https://github.com/jquery/globalize/blob/master/lib/cultures/globalize.culture.de.js
+ *
  * Dual licensed under the MIT and GPL licenses:
  * http://www.opensource.org/licenses/mit-license.php
  * http://www.gnu.org/licenses/gpl.html
@@ -106,21 +111,54 @@ $.extend($.jgrid,{
 				"Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"
 			],
 			AmPm : ["am","pm","AM","PM"],
-			S: function (j) {return 'ter'},
+			S: function (j) {return '.';}, // one can also use 'er' instead of '.' but one have to use additional word like 'der' or 'den' before
 			srcformat: 'Y-m-d',
 			newformat: 'd.m.Y',
 			masks : {
+				// see http://php.net/manual/en/function.date.php for PHP format used in jqGrid
+				// and see http://docs.jquery.com/UI/Datepicker/formatDate
+				// and https://github.com/jquery/globalize#dates for alternative formats used frequently
 		        ISO8601Long: "Y-m-d H:i:s",
 		        ISO8601Short: "Y-m-d",
-		        ShortDate: "j.n.Y",
-		        LongDate: "l, j. F Y",
-		        FullDateTime: "l, d. F Y G:i:s",
-		        MonthDay: "d. F",
-		        ShortTime: "G:i",
-		        LongTime: "G:i:s",
+				// short date:
+				//    d - Day of the month, 2 digits with leading zeros
+				//    m - Numeric representation of a month, with leading zeros
+				//    Y - A full numeric representation of a year, 4 digits
+		        ShortDate: "d.m.Y",	// in jQuery UI Datepicker: "dd.MM.yyyy"
+				// long date:
+				//    l - A full textual representation of the day of the week
+				//    j - Day of the month without leading zeros
+				//    F - A full textual representation of a month
+				//    Y - A full numeric representation of a year, 4 digits
+		        LongDate: "l, j. F Y", // in jQuery UI Datepicker: "dddd, d. MMMM yyyy"
+				// long date with long time:
+				//    l - A full textual representation of the day of the week
+				//    j - Day of the month without leading zeros
+				//    F - A full textual representation of a month
+				//    Y - A full numeric representation of a year, 4 digits
+				//    H - 24-hour format of an hour with leading zeros
+				//    i - Minutes with leading zeros
+				//    s - Seconds, with leading zeros
+		        FullDateTime: "l, j. F Y H:i:s", // in jQuery UI Datepicker: "dddd, d. MMMM yyyy HH:mm:ss"
+				// month day:
+				//    d - Day of the month, 2 digits with leading zeros
+				//    F - A full textual representation of a month
+		        MonthDay: "d F", // in jQuery UI Datepicker: "dd MMMM"
+				// short time (without seconds)
+				//    H - 24-hour format of an hour with leading zeros
+				//    i - Minutes with leading zeros
+		        ShortTime: "H:i", // in jQuery UI Datepicker: "HH:mm"
+				// long time (with seconds)
+				//    H - 24-hour format of an hour with leading zeros
+				//    i - Minutes with leading zeros
+				//    s - Seconds, with leading zeros
+		        LongTime: "H:i:s", // in jQuery UI Datepicker: "HH:mm:ss"
 		        SortableDateTime: "Y-m-d\\TH:i:s",
 		        UniversalSortableDateTime: "Y-m-d H:i:sO",
-		        YearMonth: "F Y"
+				// month with year
+				//    F - A full textual representation of a month
+				//    Y - A full numeric representation of a year, 4 digits
+		        YearMonth: "F Y" // in jQuery UI Datepicker: "MMMM yyyy"
 		    },
 		    reformatAfterEdit : false
 		},

--- a/js/i18n/grid.locale-en.js
+++ b/js/i18n/grid.locale-en.js
@@ -88,9 +88,9 @@ $.extend($.jgrid,{
 		model : "Length of colNames <> colModel!"
 	},
 	formatter : {
-		integer : {thousandsSeparator: " ", defaultValue: '0'},
-		number : {decimalSeparator:".", thousandsSeparator: " ", decimalPlaces: 2, defaultValue: '0.00'},
-		currency : {decimalSeparator:".", thousandsSeparator: " ", decimalPlaces: 2, prefix: "", suffix:"", defaultValue: '0.00'},
+		integer : {thousandsSeparator: ",", defaultValue: '0'},
+		number : {decimalSeparator:".", thousandsSeparator: ",", decimalPlaces: 2, defaultValue: '0.00'},
+		currency : {decimalSeparator:".", thousandsSeparator: ",", decimalPlaces: 2, prefix: "", suffix:"", defaultValue: '0.00'},
 		date : {
 			dayNames:   [
 				"Sun", "Mon", "Tue", "Wed", "Thr", "Fri", "Sat",
@@ -101,21 +101,58 @@ $.extend($.jgrid,{
 				"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
 			],
 			AmPm : ["am","pm","AM","PM"],
-			S: function (j) {return j < 11 || j > 13 ? ['st', 'nd', 'rd', 'th'][Math.min((j - 1) % 10, 3)] : 'th'},
+			S: function (j) {return j < 11 || j > 13 ? ['st', 'nd', 'rd', 'th'][Math.min((j - 1) % 10, 3)] : 'th';},
 			srcformat: 'Y-m-d',
-			newformat: 'd/m/Y',
+			newformat: 'n/j/Y',
 			masks : {
+				// see http://php.net/manual/en/function.date.php for PHP format used in jqGrid
+				// and see http://docs.jquery.com/UI/Datepicker/formatDate
+				// and https://github.com/jquery/globalize#dates for alternative formats used frequently
 				ISO8601Long:"Y-m-d H:i:s",
 				ISO8601Short:"Y-m-d",
-				ShortDate: "n/j/Y",
-				LongDate: "l, F d, Y",
+				// short date:
+				//    n - Numeric representation of a month, without leading zeros
+				//    j - Day of the month without leading zeros
+				//    Y - A full numeric representation of a year, 4 digits
+				// example: 3/1/2012 which means 1 March 2012
+				ShortDate: "n/j/Y", // in jQuery UI Datepicker: "M/d/yyyy"
+				// long date:
+				//    l - A full textual representation of the day of the week
+				//    F - A full textual representation of a month
+				//    d - Day of the month, 2 digits with leading zeros
+				//    Y - A full numeric representation of a year, 4 digits
+				LongDate: "l, F d, Y", // in jQuery UI Datepicker: "dddd, MMMM dd, yyyy"
+				// long date with long time:
+				//    l - A full textual representation of the day of the week
+				//    F - A full textual representation of a month
+				//    d - Day of the month, 2 digits with leading zeros
+				//    Y - A full numeric representation of a year, 4 digits
+				//    g - 12-hour format of an hour without leading zeros
+				//    i - Minutes with leading zeros
+				//    s - Seconds, with leading zeros
+				//    A - Uppercase Ante meridiem and Post meridiem (AM or PM)
 				FullDateTime: "l, F d, Y g:i:s A",
+				// month day:
+				//    F - A full textual representation of a month
+				//    d - Day of the month, 2 digits with leading zeros
 				MonthDay: "F d",
-				ShortTime: "g:i A",
-				LongTime: "g:i:s A",
+				// short time (without seconds)
+				//    g - 12-hour format of an hour without leading zeros
+				//    i - Minutes with leading zeros
+				//    A - Uppercase Ante meridiem and Post meridiem (AM or PM)
+				ShortTime: "g:i A", // in jQuery UI Datepicker: "h:mm tt"
+				// long time (with seconds)
+				//    g - 12-hour format of an hour without leading zeros
+				//    i - Minutes with leading zeros
+				//    s - Seconds, with leading zeros
+				//    A - Uppercase Ante meridiem and Post meridiem (AM or PM)
+				LongTime: "g:i:s A", // in jQuery UI Datepicker: "h:mm:ss tt"
 				SortableDateTime: "Y-m-d\\TH:i:s",
 				UniversalSortableDateTime: "Y-m-d H:i:sO",
-				YearMonth: "F, Y"
+				// month with year
+				//    Y - A full numeric representation of a year, 4 digits
+				//    F - A full textual representation of a month
+				YearMonth: "F, Y" // in jQuery UI Datepicker: "MMMM, yyyy"
 			},
 			reformatAfterEdit : false
 		},


### PR DESCRIPTION
In _grid.locale-en.js_:

Fix the values of `thousandsSeparator`, fix `newformat`, add missing ';' in the body of `S` function.

Add comments which can be helpful by people who translate the texts in other languges.

In _grid.locale-de.js_:

Fix the usage of leading zeros in date and the time.
Fix `S` function which practically not used in German. Nevertheless if one do use it the changes seems me reasonable.

Add comments which descride the options which will be used.
Add as comments the corresponding format specification which can be used in jQuery UI Datepicker.

Signed-off-by: Dr. Oleg Kiriljuk oleg.kiriljuk@ok-soft-gmbh.com
