### PR TITLE
Can use JSON dot notation with addRowData method.

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2917,7 +2917,7 @@ $.jgrid.extend({
 					for(i = gi+si+ni; i < t.p.colModel.length;i++){
 						cm = t.p.colModel[i];
 						nm = cm.name;
-                        lcdatai = $.jgrid.getAccessor(data,nm);
+						lcdatai = $.jgrid.getAccessor(data,nm);
 						lcdata[nm] = cm.formatter && typeof(cm.formatter) === 'string' && cm.formatter == 'date' ? $.unformat.date.call(t,lcdatai,cm) : lcdatai;
 						v = t.formatter( rowid, lcdatai, i, data, 'edit');
 						prp = t.formatCol(i,1,v, data, rowid, true);


### PR DESCRIPTION
EG currently using `addRowData` to add this

```
[ {"title": "t1", "attributes":{"size": "s1"}},
  {"title": "t2", "attributes.size": "s2"} ]
```

with this colModel:

```
[  { name: 'title', label: 'Title', width: 150},
   { name: 'attributes.size', label: 'Size', width: 100} ]
```

after trigger "reloadGrid" the column `'Size'` of "t1" is blank but not for "t2".
