### PR TITLE
RE: Issue #312

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -119,9 +119,15 @@ $.extend($.jgrid,{
 				}
 				if(format[k] == 'A') {
 					dM = $.inArray(date[k],afmt);
-					if(dM !== -1 && dM > 1 && date[k] == afmt[dM]){
-						date[k] = dM-2;
-						tsp.h = h12to24(date[k], tsp.h);
+					if(dM !== -1 && date[k] == afmt[dM]){
+						if (afmt[dM].toLowerCase() == 'pm') {
+							date[k] = dM-2;
+							tsp.h = h12to24(date[k], tsp.h);
+						}
+						// Convert 12 am to 0 am.
+						else if (afmt[dM].toLowerCase() == 'am' && tsp.h == 12) {
+							tsp.h = h12to24(0, tsp.h);
+						}
 					}
 				}
 				if(date[k] !== undefined) {

--- a/js/jquery.fmatter.js
+++ b/js/jquery.fmatter.js
@@ -157,6 +157,8 @@
 					timestamp.setTime(Number(Number(timestamp) + (offset * 60 * 1000)));
 				}
 			} else {
+				var ampm = '';
+
 				date = String(date).split(/[\\\/:_;.,\t\T\s-]/);
 				format = format.split(/[\\\/:_;.,\t\T\s-]/);
 				// parsing for month names
@@ -169,6 +171,13 @@
 						dM = $.inArray(date[k],dateFormat.i18n.monthNames);
 						if(dM !== -1 && dM > 11){date[k] = dM+1-12;}
 					}
+
+					// Capture the am/pm value for later
+					// conversion to 24h.
+					if (format[k].toLowerCase() == 'a') {
+						ampm = date[k].toLowerCase();
+					}
+
 					if(date[k]) {
 						ts[format[k].toLowerCase()] = parseInt(date[k],10);
 					}
@@ -181,6 +190,14 @@
 				var ty = ts.y;
 				if (ty >= 70 && ty <= 99) {ts.y = 1900+ts.y;}
 				else if (ty >=0 && ty <=69) {ts.y= 2000+ts.y;}
+				// 12 am => 0 am
+				if (ampm == 'am' && ts.h == 12) {
+					ts.h = 0;
+				}
+				// > 12 pm => h + 12 pm
+				else if (ampm == 'pm' && ts.h < 12) {
+					ts.h += 12;
+				}
 				timestamp = new Date(ts.y, ts.m, ts.d, ts.h, ts.i, ts.s, ts.u);
 			}
 			


### PR DESCRIPTION
.../pm.

When creating new Date() objects, the hour should 1st be converted to
24 hour time if necessary to prevent inaccurate date display and allow
proper sorting.

It seems there are some cases where am/pm is not being converted to the respected GMT date in the new Date() calls.  I noticed it when trying to sort dates with a source format of `Apr 25, 2012 03:01:00 pm`.
