### PR TITLE
Fixed: columns with custom html in names are missing in column chooser.

### DIFF
--- a/js/grid.jqueryui.js
+++ b/js/grid.jqueryui.js
@@ -252,7 +252,7 @@ $.jgrid.extend({
             }
 
             select.append("<option value='"+i+"' "+
-                          (this.hidden?"":"selected='selected'")+">"+colNames[i]+"</option>");
+                          (this.hidden?"":"selected='selected'")+">"+jQuery.jgrid.stripHtml(colNames[i])+"</option>");
         });
         function call(fn, obj) {
             if (!fn) { return; }


### PR DESCRIPTION
It just strips html from their names and they appear in the selection dialog.
