### PR TITLE
beginReq and endReq should be public properties of grid

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2589,7 +2589,7 @@ $.fn.jqGrid = function( pin ) {
 		ts.setHeadCheckBox = setHeadCheckBox;
 		ts.constructTr = constructTr;
 		ts.formatter = function ( rowId, cellval , colpos, rwdat, act){return formatter(rowId, cellval , colpos, rwdat, act);};
-		$.extend(grid,{populate : populate, emptyRows: emptyRows});
+		$.extend(grid,{populate : populate, emptyRows: emptyRows, beginReq: beginReq, endReq: endReq});
 		this.grid = grid;
 		ts.addXmlData = function(d) {addXmlData(d,ts.grid.bDiv);};
 		ts.addJSONData = function(d) {addJSONData(d,ts.grid.bDiv);};


### PR DESCRIPTION
When using a custom defined `datatype` function for retrieving data, it's best to use the already existing methods for `loadui`.

Here's an example:

``` js
jQuery("#list").jqGrid({
  loadui: 'block',
  datatype: function(args){
    var grid= this;
    grid.beginReq(); // Show the loading indicator
    CustomAjax.invoke({
      url: 'hosting.php',
      params: args,
      successCallback: function(response) {
        grid.addJSONData(response.getValue('accounts'));
        grid.endReq(); // Hide the loading indicator
      },
      errorCallback: function(response) {
        // ... Add error to message container
        grid.endReq(); // Hide the loading indicator
      }
  }
  ...
});
```

Kind regards,
      g.
