### PR TITLE
Update grid.base.js fixes bug with autoscrolling

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1316,7 +1316,10 @@ $.fn.jqGrid = function( pin ) {
 				frd='json';
 			}
 			var ir=0,v,i,j,f=[],F,cur,gi=ts.p.multiselect?1:0,si=ts.p.subGrid?1:0,ni=ts.p.rownumbers===true?1:0,len,drows,idn,rd={}, fpos, idr,rowData=[],cn=(ts.p.altRows === true) ? " "+ts.p.altclass:"",cn1,lp;
-			ts.p.page = $.jgrid.getAccessor(data,dReader.page) || 0;
+			//if response provides page number, use it
+			//elseif page number is set, last it unchanged
+			//elseif initialize it with zero
+			ts.p.page = $.jgrid.getAccessor(data,dReader.page) || ts.p.page || 0;
 			lp = $.jgrid.getAccessor(data,dReader.total);
 			ts.p.lastpage = lp === undefined ? 1 : lp;
 			ts.p.records = $.jgrid.getAccessor(data,dReader.records) || 0;


### PR DESCRIPTION
Bug was: (if response doesn't provide page number, every time page number 2 is requested)
Now jqGrid uses the page number it requested to continue auto loading for many pages until actual scroll position is reached.
