### PR TITLE
fix for issue #131

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1761,7 +1761,13 @@ $.fn.jqGrid = function( pin ) {
 					$(ts).jqGrid('groupingSetup');
 					var grp = ts.p.groupingView, gi, gs="";
 					for(gi=0;gi<grp.groupField.length;gi++) {
-						gs += grp.groupField[gi]+" "+grp.groupOrder[gi]+", ";
+						var index = grp.groupField[gi];
+						$.each(ts.p.colModel, function(cmIndex, cmValue) {
+							if (cmValue.name == index && cmValue.index){
+								index = cmValue.index;
+							}
+						} );
+						gs += index +" "+grp.groupOrder[gi]+", ";
 					}
 					prm[pN.sort] = gs + prm[pN.sort];
 				}


### PR DESCRIPTION
When grouping is enabled, jqGrid adds the grouping fields to the sort columns. However convention says if the colModel has an index defined along with the name, then the inde should be used for sorting and not the name. Currently, jqGrid will send the name as the parameter to sort on irrespective of whether the index is defined or not. 

The fix checks whether an index is defined in the respective colModel  definition and uses that if present.

This works on my machine! I might not have covered all possible scenarios. If you can guide me in that direction, I can cover those areas as well. 
