### PR TITLE
Always pass form operation ("add" or "edit") to the jqGridAddEditBeforeInitData event

### DIFF
--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -904,7 +904,7 @@ $.jgrid.extend({
 			}
 
 			if ( $("#"+$.jgrid.jqID(IDs.themodal)).html() !== null ) {
-				showFrm = $($t).triggerHandler("jqGridAddEditBeforeInitData", [$("#"+$.jgrid.jqID(frmgr))]);
+				showFrm = $($t).triggerHandler("jqGridAddEditBeforeInitData", [$("#"+$.jgrid.jqID(frmgr)), frmoper]);
 				if(typeof(showFrm) == "undefined") {
 					showFrm = true;
 				}


### PR DESCRIPTION
I noticed that the form operation `frmoper` is not always being passed to the `jqGridAddEditBeforeInitData` event. I see no reason not to pass it since it is always available, and it make the event's interface consistent. But do please let me know if I missed something.
