### PR TITLE
tabindex attribute changed from 1 to 0.

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -933,7 +933,7 @@ $.fn.jqGrid = function( pin ) {
 				return;
 			}
 		}
-		$(this).empty().attr("tabindex","1");
+		$(this).empty().attr("tabindex","0");
 		this.p = p ;
 		this.p.useProp = !!$.fn.prop;
 		var i, dir;


### PR DESCRIPTION
Having the tabindex set to 1 was causing the focus to jump around the screen quite a bit e.g. hitting <tab> would go straight to the jqGrid, but subsequent <tab> key presses would then jump back up
to the main navigational links.

Changing the tabindex to zero meant that jqGrid <table> can still receive the focus, but receives it according to the normal document flow.
