### PR TITLE
Fix for issue #189

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1625,7 +1625,7 @@ $.fn.jqGrid = function( pin ) {
 			page = parseInt(ts.p.page,10),
 			totalpages = Math.ceil(total / recordsperpage),
 			retresult = {};
-			queryResults = queryResults.slice( (page-1)*recordsperpage , page*recordsperpage );
+			if(page*recordsperpage != -1) { queryResults = queryResults.slice( (page-1)*recordsperpage , page*recordsperpage ); }
 			query = null;
 			cmtypes = null;
 			retresult[ts.p.localReader.total] = totalpages;


### PR DESCRIPTION
Fix for issue #189.  When the parameter rowNum is set to -1, queryResults slices from 0 to -1.  That means, it includes all array data, except the last row.  I do not think this was intentional.

Please be gentle, this is my first time attempting to contribute to open source.  Constructive criticism is encouraged.
