### PR TITLE
Fixed search filters addition/deletion

### DIFF
--- a/js/grid.filter.js
+++ b/js/grid.filter.js
@@ -453,8 +453,10 @@ $.fn.jqFilter = function( arg ) {
 				}
 			}
 			var ruleDataInput = $.jgrid.createEl(cm.inputtype,cm.searchoptions, rule.data, true, that.p.ajaxSelectOptions, true);
-			if(rule.op == 'nu' || rule.op == 'nn')
-                		$(ruleDataInput).attr('readonly','readonly'); //retain the state of disabled text fields in case of null ops
+			if(rule.op == 'nu' || rule.op == 'nn') {
+                		$(ruleDataInput).attr('readonly','true');
+                		$(ruleDataInput).attr('disabled','true');
+            		} //retain the state of disabled text fields in case of null ops
 			// dropdown for: choosing operator
 			var ruleOperatorSelect = $("<select class='selectopts'></select>");
 			ruleOperatorTd.append(ruleOperatorSelect);


### PR DESCRIPTION
Issue
1. Select not null/is null from filter
2. Try adding another filter.
3. Notice the fields against not null/is null filter are not readonly anymore.

This fix maintains the readonly state for search ops involving null.
