### PR TITLE
Don't call internal width change code if the width is still the same

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -3161,10 +3161,10 @@ $.jgrid.extend({
 	setGridWidth : function(nwidth, shrink) {
 		return this.each(function(){
 			if (!this.grid ) {return;}
-			if (isNaN(nwidth)) { return; }
-			nwidth = parseInt(nwidth, 10);
+			if (isNaN(nwidth)) {return;}
+			nwidth = parseInt(nwidth,10);
 			// if the width matches the current grid and pager width we shouldn't make any changes to the grid width as this can cause an infinite window.resize loop in IE.
-			if(this.grid.width == nwidth && this.p.width == nwidth){return;}
+			if(this.grid.width==nwidth && this.p.width==nwidth){return;}
 			var $t = this, cw,
 			initwidth = 0, brd=$.jgrid.cellWidth() ? 0: $t.p.cellLayout, lvc, vc=0, hs=false, scw=$t.p.scrollOffset, aw, gw=0,
 			cl = 0,cr;


### PR DESCRIPTION
This pull request stops an infinite loop of window.resize events happening in Internet Explorer if you set the grid width inside a window.resize event callback.

This issue caused a browser hang for us in IE 9 (and presumably IE 10) if the user gets logged out of a page that contains a grid due to a 30 minute timeout.
