### PR TITLE
Add destroyFilterToolbar method

### DIFF
--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -133,7 +133,7 @@ $.jgrid.extend({
 			$("#gbox_"+gid).remove();
 		});
 	},
-    setGridState : function(state) {
+	setGridState : function(state) {
 		return this.each(function(){
 			if ( !this.grid ) {return;}
 			var $t = this;
@@ -476,7 +476,18 @@ $.jgrid.extend({
 			this.toggleToolbar = toggleToolbar;
 		});
 	},
-
+	destroyFilterToolbar: function () {
+		return this.each(function () {
+			if (!this.ftoolbar) {
+				return;
+			}
+			this.triggerToolbar = null;
+			this.clearToolbar = null;
+			this.toggleToolbar = null;
+			this.ftoolbar = false;
+			$(this.grid.hDiv).find("table thead tr.ui-search-toolbar").remove();
+		});
+	},
 	destroyGroupHeader : function(nullHeader)
 	{
 		if(typeof(nullHeader) == 'undefined') {
@@ -517,7 +528,6 @@ $.jgrid.extend({
 			}
 		});
 	},
-	
 	setGroupHeaders : function ( o ) {
 		o = $.extend({
 			useColSpanStyle :  false,


### PR DESCRIPTION
Hello Tony,

as mention before I suggest here the method `destroyFilterToolbar` which could be practical to recreate the searching toolbar.

One can find in [the answer](http://stackoverflow.com/a/13700184/315935) an example of the usage of the method with a practical use case.

Best regards
Oleg
