### PR TITLE
Adding ** to the top comment so that the licence information doesn't get removed by the newest Google Closure compiler

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1,7 +1,7 @@
 // ==ClosureCompiler==
 // @compilation_level SIMPLE_OPTIMIZATIONS
 
-/*
+/**
  * @license jqGrid  4.4.1  - jQuery Grid
  * Copyright (c) 2008, Tony Tomov, tony@trirand.com
  * Dual licensed under the MIT and GPL licenses


### PR DESCRIPTION
If you build the jqGrid source using the latest Google Closure compiler it removes the licensing information from the file it produces.

This pull stops that from happening.
