### PR TITLE
postData for building selects using dataUrl

### DIFF
--- a/js/grid.common.js
+++ b/js/grid.common.js
@@ -181,7 +181,6 @@ $.extend($.jgrid,{
 			try{$(':input:visible',selector)[0].focus();}catch(_){}
 		}
 	},
-
 	info_dialog : function(caption, content,c_b, modalopt) {
 		var mopt = {
 			width:290,
@@ -340,10 +339,19 @@ $.extend($.jgrid,{
 					$(elem).attr("aria-multiselectable","true");
 				} else { msl = false; }
 				if(options.dataUrl !== undefined) {
+					var rowid = options.name ? String(options.id).substring(0, String(options.id).length - String(options.name).length - 1) : String(options.id),
+						postData = options.postData || ajaxso.postData;
+
+					if ($t.p && $t.p.idPrefix) {
+						rowid = $.jgrid.stripPref($t.p.idPrefix, rowid);
+					} else {
+						postData = undefined; // don't use postData for searching from jqFilter. One can implement the feature in the future if required.
+					}
 					$.ajax($.extend({
 						url: options.dataUrl,
 						type : "GET",
 						dataType: "html",
+						data: $.isFunction(postData) ? postData.call($t, rowid, vl, String(options.name)) : postData,
 						context: {elem:elem, options:options, vl:vl},
 						success: function(data){
 							var a,	ovm = [], elem = this.elem, vl = this.vl,


### PR DESCRIPTION
Hi Tony,

I read regularly the requirement to send some additional information to the `dataUrl` needed to construct `<select>` in for data editing. The problem is that in some scenarios one have practically no additional possibility to modify `dataUrl` before the request to `dataUrl` will be sent. For example [the answer](http://stackoverflow.com/a/13913788/315935) described the workaround in case of usage `formatter: "actions"`.

Small changes which I prepared as pull request allows to solve the problem in very easy way. After the suggested modification one can use `editoptions.postData` or `ajaxSelectOptions.postData` for the purpose. For example as

```
ajaxSelectOptions: {
    postData: function (rowid, value, colName) {
        return { id: rowid, val: value, col: colName };
    }
}
```

or as

```
editoptions: {
    dataUrl: "/Home/GetSelectData",
    postData: function (rowid, value, colName) {
        return { id: rowid, val: value, col: colName };
    }
}
```

If required one can use `rowid` to get and post some other context specific information from the grid.

The modified method `$.jgrid.createEl` will be used from jqFilter too. In the same `rowid` will be set to the random value `$.jgrid.randId()`. Because of that I suggest don't use the suggested functionality in case of searching.

Best regards
Oleg
