### PR TITLE
Update js/grid.formedit.js

### DIFF
--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -746,7 +746,7 @@ $.jgrid.extend({
 										postdata[n] = $.jgrid.htmlDecode(v);
 									});
 								}
-								//rp_ge[$t.p.id].reloadAfterSubmit = rp_ge[$t.p.id].reloadAfterSubmit && $t.p.datatype != "local";
+								rp_ge[$t.p.id].reloadAfterSubmit = rp_ge[$t.p.id].reloadAfterSubmit && $t.p.datatype != "local";
 								// the action is add
 								if(postdata[oper] == opers.addoper ) {
 									//id processing


### PR DESCRIPTION
With current line commenting in the case when you need to add or edit a line on client side it doesnt work because variable "reloadAfterSubmit"=true PERMANENTLY and so grid only reloaded in ANY case!  nothing happens after trying to add a line.

This fix solving problem: when datatype set up to local -  adding and editing on client side WORK!
