### PR TITLE
case sensitive sorting of local data

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -327,8 +327,8 @@ $.extend($.jgrid,{
 				return 0;
 			}
 			if(!_usecase && typeof a !== "number" && typeof b !== "number" ) {
-				a=String(a).toLowerCase();
-				b=String(b).toLowerCase();
+				a=String(a);
+				b=String(b);
 			}
 			if(a<b){return -d;}
 			if(a>b){return d;}
@@ -378,8 +378,8 @@ $.extend($.jgrid,{
 				findSortKey = type;
 			} else {
 				findSortKey = function($cell) {
-					if(!$cell) {$cell ="";}
-					return $.trim(String($cell).toUpperCase());
+					$cell = $cell ? $.trim(String($cell)) : "";
+					return _usecase ? $cell : $cell.toLowerCase();
 				};
 			}
 			$.each(data,function(i,v){


### PR DESCRIPTION
Hi Tony,

event with the option `ignoreCase: false` local sorting of grid is not case sensitive now. After the suggestion changes the problem will be fixed. Additionally I changed the case of strings used during comparing from low case to upper case and removed `toLowerCase` call from `_compare` which should improve the performance a little.

[The demo](http://www.ok-soft-gmbh.com/jqGrid/CaseSensitiveSorting0.htm) displays the following results:

<img src="http://www.ok-soft-gmbh.com/jqGrid/CaseSensitiveSorting0.png" alt="bug" />

[Another demo](http://www.ok-soft-gmbh.com/jqGrid/CaseSensitiveSorting.htm), which use the fixed code, display as the results the following:

<img src="http://www.ok-soft-gmbh.com/jqGrid/CaseSensitiveSorting.png" alt="fix" />

Best regards
Oleg
