### PR TITLE
Adds the option to have a different title from the value used for grouping

### DIFF
--- a/js/grid.grouping.js
+++ b/js/grid.grouping.js
@@ -78,23 +78,23 @@ $.jgrid.extend({
 			var grp = this.p.groupingView, $t= this, i,
 			grlen = grp.groupField.length, 
 			fieldName,
-            titleField,
+			titleField,
 			v,
 			displayName,
 			displayValue,
-            titleValue,
+			titleValue,
 			changed = 0;
 			for(i=0;i<grlen;i++) {
 				fieldName = grp.groupField[i];
 				displayName = grp.displayField[i];
-                titleField = grp.titleField == null ? null : grp.titleField[i];
+				titleField = grp.titleField == null ? null : grp.titleField[i];
 				v = record[fieldName];
 				displayValue = displayName == null ? null : record[displayName];
 
 				if( displayValue == null ) {
 					displayValue = v;
 				}
-                titleValue = titleField == null ? null : record[titleField];
+				titleValue = titleField == null ? null : record[titleField];
 				if( v !== undefined ) {
 					if(irow === 0 ) {
 						// First record always starts a new group


### PR DESCRIPTION
Similar to pull #402.

This is useful if the name you want to use for grouping is too long to be cleanly displayed to the user, and it allows you to display a shorter display label and still make the full display label available to the user if they hover.
