### PR TITLE
Form Editing, multi-select: optionally return array of selected values instead of comma-separated string

### DIFF
--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -408,8 +408,15 @@ $.jgrid.extend({
 						break;
 						case "select-multiple":
 							postdata[this.name]= $(this).val();
-							if(postdata[this.name]) {postdata[this.name] = postdata[this.name].join(",");}
-							else {postdata[this.name] ="";}
+							var nm = $(this).attr('name'), encToString = true;
+							$.each($t.p.colModel, function(){
+								if(this.name === nm && this.editoptions && this.editoptions.arrayValue === true)
+									encToString = false; 
+							});
+							if (encToString){
+								if(postdata[this.name]) {postdata[this.name] = postdata[this.name].join(",");}
+								else {postdata[this.name] ="";}
+							}
 							var selectedText = [];
 							$("option:selected",this).each(
 								function(i,selected){


### PR DESCRIPTION
For server-side handling comparibility with regular HTML forms,
in Form Editing mode, for multi-select field, allow `arrayValue` editoption, which - if set to True - will return an array of selected options, instead of comma-separated values list.

example: we have select field and selected options with values of 10 and 11. 
Normally, jqGrid Form Edit would send to the server the value of `"10,11"` - which is comma-separated list of selected values. However, if we want to retrieve an array of selected values, like `['10','11']` - there is a new option `arrayValue: true`.

```
{
...
edittype: 'select',
editoptions: { arrayValue: true },
}
```
