### PR TITLE
small improvements in getOffset method

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2150,19 +2150,16 @@ $.fn.jqGrid = function( pin ) {
 			return j-ret;
 		},
 		getOffset = function (iCol) {
-			var i, ret = {}, brd1 = $.jgrid.cell_width ? 0 : ts.p.cellLayout;
-			ret[0] =  ret[1] = ret[2] = 0;
+			var i, ret = [0], brd1 = $.jgrid.cell_width ? 0 : ts.p.cellLayout;
 			for(i=0;i<=iCol;i++){
 				if(ts.p.colModel[i].hidden === false ) {
 					ret[0] += ts.p.colModel[i].width+brd1;
 				}
 			}
 			if(ts.p.direction=="rtl") { ret[0] = ts.p.width - ret[0]; }
-			ret[0] = ret[0] - ts.grid.bDiv.scrollLeft;
-			if($(ts.grid.cDiv).is(":visible")) {ret[1] += $(ts.grid.cDiv).height() +parseInt($(ts.grid.cDiv).css("padding-top"),10)+parseInt($(ts.grid.cDiv).css("padding-bottom"),10);}
-			if(ts.p.toolbar[0]===true && (ts.p.toolbar[1]=='top' || ts.p.toolbar[1]=='both')) {ret[1] += $(ts.grid.uDiv).height()+parseInt($(ts.grid.uDiv).css("border-top-width"),10)+parseInt($(ts.grid.uDiv).css("border-bottom-width"),10);}
-			if(ts.p.toppager) {ret[1] += $(ts.grid.topDiv).height()+parseInt($(ts.grid.topDiv).css("border-bottom-width"),10);}
-			ret[2] += $(ts.grid.bDiv).height() + $(ts.grid.hDiv).height();
+			ret[0] -= ts.grid.bDiv.scrollLeft;
+			ret.push($(ts.grid.hDiv).position().top);
+			ret.push($(ts.grid.bDiv).offset().top - $(ts.grid.hDiv).offset().top + $(ts.grid.bDiv).height());
 			return ret;
 		},
 		getColumnHeaderIndex = function (th) {


### PR DESCRIPTION
Hello Tony,

I suggest small improvements in `getOffset` method. If simplify the calculation of the height and position of resizing bar. After the changes the resizing bar will be correct even in case of non-standard oder of some dives or in case of manually added custom information in some divs.

The idea is very simple. It's not so important the exact size of different dived in the grid. One need just use the position of column header (position of `hDiv`) which will be starting position of the bar and one should make the height of the bar be till the bottom of the `bDiv`. Sizes of any other dives are not so important.

[The demo](http://www.ok-soft-gmbh.com/jqGrid/TopFooter1.htm) demonstrate the results of changing. You can compare the results of the demo with [the same demo](http://www.ok-soft-gmbh.com/jqGrid/TopFooter1_.htm) where jqGrid 4.4.3 are used.

Best regards
Oleg
