### PR TITLE
fixing the bug in local searching in case of non-empty group and rules and OR operation

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1575,7 +1575,8 @@ $.fn.jqGrid = function( pin ) {
 				var s = 0, index, gor, ror, opr, rule;
 				if (group.groups != null && group.groups.length > 0) {
 					if (group.rules != null && group.rules.length > 0) {
-						// move rule inside if group as additional subgroup
+						// move the rules inside of the group so that the group
+						// has as additional subgroup with the rules 
 						group.groups.push({
 							groupOp: group.groupOp,
 							rules: group.rules,


### PR DESCRIPTION
Hello Tony,

it seems to me that I found simple and safe way to fix the bug described in [the bug report](http://www.trirand.com/blog/?page_id=393/bugs/bug-in-local-searching/#p28113). The solution is very easy. It seems that sorting works fine with non-empty group and **empty rule**. So I suggest to move the `rules` part in one more additional group. An example of such transformation you can find in [the answer](http://stackoverflow.com/a/14521000/315935).

[The demo](http://www.ok-soft-gmbh.com/jqGrid/SearchingDialogAboveGrid1.htm) demonstrate the fix.

Best regards
Oleg
