### PR TITLE
Enabling the freeze columns on treegrid

### DIFF
--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -656,7 +656,7 @@ $.jgrid.extend({
 			if ( !this.grid ) {return;}
 			var $t = this, cm = $t.p.colModel,i=0, len = cm.length, maxfrozen = -1, frozen= false;
 			// TODO treeGrid and grouping  Support
-			if($t.p.subGrid === true || $t.p.treeGrid === true || $t.p.cellEdit === true || $t.p.sortable || $t.p.scroll || $t.p.grouping )
+			if($t.p.subGrid === true || $t.p.cellEdit === true || $t.p.sortable || $t.p.scroll || $t.p.grouping )
 			{
 				return;
 			}

--- a/js/grid.treegrid.js
+++ b/js/grid.treegrid.js
@@ -195,7 +195,7 @@ $.jgrid.extend({
 			rows = $t.rows;
 			$(childern).each(function(){
 				var id  = $.jgrid.getAccessor(this,$t.p.localReader.id);
-				$(rows.namedItem(id)).css("display","");
+				$('#'+id,'#'+$t.id+'_frozen, #'+$t.id).css("display","");
 				if(this[expanded]) {
 					$($t).jqGrid("expandRow",this);
 				}
@@ -212,7 +212,7 @@ $.jgrid.extend({
 			rows = $t.rows;
 			$(childern).each(function(){
 				var id  = $.jgrid.getAccessor(this,$t.p.localReader.id);
-				$(rows.namedItem(id)).css("display","none");
+				$('#'+id,'#'+$t.id+'_frozen, #'+$t.id).css("display","none");
 				if(this[expanded]){
 					$($t).jqGrid("collapseRow",this);
 				}


### PR DESCRIPTION
Changing the lines 198 from "$(rows.namedItem(id)).css("display","");" to "$('#'+id,'#'+$t.id+'_frozen, #'+$t.id).css("display","");" I was able to set frozen columns on treegrid. I´ve done the same on the collapseRow function. I have to change too the grid.custom.js to enable the feature.