### PR TITLE
small improvements in getOffset method

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2151,12 +2151,7 @@ $.fn.jqGrid = function( pin ) {
 			return j-ret;
 		},
 		getOffset = function (iCol) {
-			var i, ret = [0], brd1 = $.jgrid.cell_width ? 0 : ts.p.cellLayout;
-			for(i=0;i<=iCol;i++){
-				if(ts.p.colModel[i].hidden === false ) {
-					ret[0] += ts.p.colModel[i].width+brd1;
-				}
-			}
+			var $th = $(ts.grid.headers[iCol].el), ret = [$th.position().left + $th.outerWidth()];
 			if(ts.p.direction=="rtl") { ret[0] = ts.p.width - ret[0]; }
 			ret[0] -= ts.grid.bDiv.scrollLeft;
 			ret.push($(ts.grid.hDiv).position().top);


### PR DESCRIPTION
Hi Tony,

I suggest to simplify a little the code of `getOffset` function. Additionally it will be removed dependency from `cellLayout` and `$.jgrid.cellWidth` from the code.

By the way the input parameter of  `getOffset` function (`iCol`) will be get from the previous call of `getColumnHeaderIndex` (see [here](https://github.com/tonytomov/jqGrid/blob/v4.4.4/js/grid.base.js#L2371-L2373)) which uses internally `ts.grid.headers[i].el` expression in the loop (see [the source code](https://github.com/tonytomov/jqGrid/blob/v4.4.4/js/grid.base.js#L2166-L2175)). So there are no need to include in code of `getOffset` function any validation whether the expression `$th = $(ts.grid.headers[iCol].el)` from the suggested code is correct or not. It's always valid.

Best regards
Oleg
