### PR TITLE
improving performance of local sorting

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -344,6 +344,14 @@ $.extend($.jgrid,{
 			if(a>b){return d;}
 			return 0;
 		};
+		this._simpleNumberCompare = function (a, b, d) {
+			return d > 0 ? a - b : b - a;
+		};
+		this._simpleCompare = function (a, b, d) {
+			if(a<b){return -d;}
+			if(a>b){return d;}
+			return 0;
+		};
 		this._performSort=function(){
 			if(_sorting.length===0){return;}
 			_data=self._doSort(_data,0);
@@ -367,42 +375,42 @@ $.extend($.jgrid,{
 			return results;
 		};
 		this._getOrder=function(data,by,dir,type, dfmt){
-			var sortData=[],_sortData=[], newDir = dir=="a" ? 1 : -1, i,ab,j,
-			findSortKey;
+			var sortData=[],_sortData=[], newDir = dir=="a" ? 1 : -1, i, j,
+			normalizedSortKey,getAccessor=$.jgrid.getAccessor,compare=self._simpleCompare;
 
 			if(type === undefined ) { type = "text"; }
 			if (type == 'float' || type== 'number' || type== 'currency' || type== 'numeric') {
-				findSortKey = function($cell) {
+				normalizedSortKey = function($cell) {
 					var key = parseFloat( String($cell).replace(_stripNum, ''));
 					return isNaN(key) ? 0.00 : key;
 				};
+				compare=self._simpleNumberCompare;
 			} else if (type=='int' || type=='integer') {
-				findSortKey = function($cell) {
+				normalizedSortKey = function($cell) {
 					return $cell ? parseFloat(String($cell).replace(_stripNum, '')) : 0;
 				};
+				compare=self._simpleNumberCompare;
 			} else if(type == 'date' || type == 'datetime') {
-				findSortKey = function($cell) {
+				normalizedSortKey = function($cell) {
 					return $.jgrid.parseDate(dfmt,$cell).getTime();
 				};
 			} else if($.isFunction(type)) {
-				findSortKey = type;
+				normalizedSortKey = type;
+				compare=self._compare;
 			} else {
-				findSortKey = function($cell) {
+				normalizedSortKey = function($cell) {
 					$cell = $cell ? $.trim(String($cell)) : "";
 					return _usecase ? $cell : $cell.toLowerCase();
 				};
 			}
 			$.each(data,function(i,v){
-				ab = by!=="" ? $.jgrid.getAccessor(v,by) : v;
+				var ab = by!=="" ? $.jgrid.getAccessor(v,by) : v;
 				if(ab === undefined) { ab = ""; }
-				ab = findSortKey(ab, v);
-				_sortData.push({ 'vSort': ab,'index':i});
+				_sortData.push({ vSort: normalizedSortKey(ab, v), index: i});
 			});
 
 			_sortData.sort(function(a,b){
-				a = a.vSort;
-				b = b.vSort;
-				return self._compare(a,b,newDir);
+				return compare(a.vSort,b.vSort,newDir);
 			});
 			j=0;
 			var nrec= data.length;


### PR DESCRIPTION
Hello Tony,

the function `_compare` will be used for both local sorting and local filtering of data. I think that at least in case of local sorting one can use reduced form of the function. I didn't make any exact measurements, but short code must follow better performance.

The function `_getOrder` used during local sorting place first *normilized* values from the  sorting column inside of `_sortData`. So no `undefined` and `null` values can be used during comparing in the case. One uses *different* implementation of function `findSortKey` (which I `normalizedSortKey`), so all `vSort` values have **the same** type. So the simplified version `_simpleCompare` or even as `_simpleNumberCompare` could be used. Only if one use function as `sorttype` the compared values cab be common and one can use more common `_compare` implementation.

Probably one can improve performance of `_getGroup` additionally by the usage `self._equals` without `null` as the first initial value of `last` variable. In the case one will be able to change `self._equals` to use `_simpleCompare` instead of `_compare`.

Best regards
Oleg