### PR TITLE
Update js/grid.base.js to correct bug when virtual scroll is active and initial page number is not = 1

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1678,6 +1678,9 @@ $.fn.jqGrid = function( pin ) {
 					var top = base * rh;
 					var height = parseInt(ts.p.records,10) * rh;
 					$(">div:first",ts.grid.bDiv).css({height : height}).children("div:first").css({height:top,display:top?"":"none"});
+					if (ts.grid.bDiv.scrollTop == 0 && ts.p.page > 1) {
+						ts.grid.bDiv.scrollTop = ts.p.rowNum * (ts.p.page - 1) * rh;
+					}
 				}
 				ts.grid.bDiv.scrollLeft = ts.grid.hDiv.scrollLeft;
 			}


### PR DESCRIPTION
Scroll automatically the grid when virtual scroll is active and the initial page number is set in grid's options with a value > 1.
See http://www.trirand.com/blog/?page_id=393/help/virtual-scroll-ajax-xml-data-go-to-page-programmatically/
