### PR TITLE
Update js/grid.celledit.js

### DIFF
--- a/js/grid.celledit.js
+++ b/js/grid.celledit.js
@@ -353,7 +353,7 @@ $.jgrid.extend({
 			if (!$t.grid || $t.p.cellEdit !== true ) {return;}
 			// trick to process keydown on non input elements
 			$t.p.knv = $t.p.id + "_kn";
-			var selection = $("<div style='position:fixed;top:-1000000px;width:1px;height:1px;' tabindex='0'><div tabindex='-1' style='width:1px;height:1px;' id='"+$t.p.knv+"'></div></div>"),
+			var selection = $("<div style='position:fixed;top:0px;width:1px;height:1px;' tabindex='0'><div tabindex='-1' style='width:1px;height:1px;' id='"+$t.p.knv+"'></div></div>"),
 			i, kdir;
 			function scrollGrid(iR, iC, tp){
 				if (tp.substr(0,1)=='v') {


### PR DESCRIPTION
Correct the scroll page bug when clicking on a non-editable cell when celledit mode is active. This bug can be seen only in Chrome.
It can be reproduced with this test case :
http://jsfiddle.net/lgoncalves/zcm2C/
I apply the suggestion of sergey68 in 
http://www.trirand.com/blog/?page_id=393/bugs/grid-scrolls-to-top-after-selecting-a-cell/page-2/
and with this correction the bug is corrected.
