### PR TITLE
FIX: Dragging a row to sort it screws up cell widths

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1054,12 +1054,10 @@ $.fn.jqGrid = function( pin ) {
 			return order;
 		},
 		emptyRows = function (scroll, locdata) {
-			var firstrow;
 			if (this.p.deepempty) {
 				$(this.rows).slice(1).remove();
 			} else {
-				firstrow = this.rows.length > 0 ? this.rows[0] : null;
-				$(this.firstChild).empty().append(firstrow);
+                $(this.firstChild).find('tr:not(:first)').remove();
 			}
 			if (scroll && this.p.scroll) {
 				$(this.grid.bDiv.firstChild).css({height: "auto"});


### PR DESCRIPTION
Hi, guys.
I found solution how to fix some bug and think that I must share it with you to make jqGrid better.

Details are here:
http://stackoverflow.com/questions/9203917/jqgrid-dragging-a-row-to-sort-it-screws-up-cell-widths

Check my post - I'm "PokatilovArt" on StackOverflow.

Solution seems very clear. I tested it in Chrome, FF and IE 8-9.
