### PR TITLE
not exact grouping / grouping by intervals of values

### DIFF
--- a/js/grid.grouping.js
+++ b/js/grid.grouping.js
@@ -106,7 +106,7 @@ $.jgrid.extend({
 						});
 						grp.groups[grp.counters[i].pos].summary = grp.counters[i].summary;
 					} else {
-						if( typeof v !== "object" && grp.lastvalues[i] !== v ) {
+						if (typeof v !== "object" && ($.isArray(grp.isInTheSameGroup) && $.isFunction(grp.isInTheSameGroup[i]) ? ! grp.isInTheSameGroup[i].call($t, grp.lastvalues[i], v, i, grp): grp.lastvalues[i] !== v)) {
 							// This record is not in same group as previous one
 							grp.groups.push({idx:i,dataIndex:fieldName,value:v, displayValue: displayValue, startRow: irow, cnt:1, summary : [] } );
 							grp.lastvalues[i] = v;
@@ -257,6 +257,9 @@ $.jgrid.extend({
 				hid = clid+"_"+i;
 				icon = "<span style='cursor:pointer;' class='ui-icon "+pmrtl+"' onclick=\"jQuery('#"+$.jgrid.jqID($t.p.id)+"').jqGrid('groupingToggle','"+hid+"');return false;\"></span>";
 				try {
+					if ($.isArray(grp.formatDisplayField) && $.isFunction(grp.formatDisplayField[n.idx])) {
+						n.displayValue = grp.formatDisplayField[n.idx].call($t, n.displayValue, n.value, $t.p.colModel[cp[n.idx]], n.idx, grp);
+					}
 					gv = $t.formatter(hid, n.displayValue, cp[n.idx], n.value );
 				} catch (egv) {
 					gv = n.displayValue;


### PR DESCRIPTION
Hello,

after writing [the answer](http://stackoverflow.com/a/16152739/315935) I examined more exact the possibilities extending of jqGrid grouping so that not only exact values can be used to build groups. I think that I found very simple and flexible enough way which
1. support of "not exact" grouping by introducing `isInTheSameGroup` array of callbacks in `groupingView`.
2. more flexibility in constructing of `displayField` by introducing of `formatDisplayField` array of callbacks in `groupingView`.

The results of the suggested modifications one can see on [the demo](http://www.ok-soft-gmbh.com/jqGrid/NotExactGrouping1.htm) which displays the results like the following

<img src="http://www.ok-soft-gmbh.com/jqGrid/NotExactGrouping1.png"/>

One can see that the grouping on the first level will be done in case-insensitive way and that the values will be displayed in low case in the grouping header.

One can see that the grouping on the second level will be done by _intervals_ of values (by year and month). The  grouping header display also no day of the grouping element.

I tried to make the changes to make full compatibility with existing grids.

I hope that such changes will be helpfully for other users of jqGrid.

Best regards
Oleg
