### PR TITLE
fix usage of `columns` parameter of `searchGrid` in combination with `multipleSearch: false`

### DIFF
--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -134,7 +134,7 @@ $.jgrid.extend({
 					} else if(p.sopt && p.sopt.length) {
 						cmop = p.sopt[0];
 					}
-					defaultFilters = {"groupOp": "AND",rules:[{"field":colnm,"op":cmop,"data":""}]};
+					defaultFilters = {groupOp: "AND", rules: [{field: colnm, op: cmop, data: ""}]};
 				}
 				found = false;
 				if(p.tmplNames && p.tmplNames.length) {


### PR DESCRIPTION
Hello Tony,

The method `searchGrid` provides `columns` parameter which allows to specify the order of columns displayed in the dropdown of the Searching Dialog which allows to choose the column in the searching rule. The current implementation fills `undefined` value for `field` property of default rule in [the line](https://github.com/tonytomov/jqGrid/blob/v4.4.5/js/grid.formedit.js#L138). Suggested fix solves the problem.

[The demo](http://www.ok-soft-gmbh.com/jqGrid/OrderOfColumnInSingleValueSearching.htm) created for [the answer](http://stackoverflow.com/a/16467819/315935) uses suggested here fix.

Best regards
Oleg
