### PR TITLE
fix date format parsing for full month name when full name and abbreviation are equal

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -127,7 +127,7 @@ $.extend($.jgrid,{
 						if(dM !== -1 && dM < 12){date[k] = dM+1; ts.m = date[k];}
 					}
 					if(format[k] === 'F') {
-						dM = $.inArray(date[k],opts.monthNames);
+						dM = $.inArray(date[k],opts.monthNames,12);
 						if(dM !== -1 && dM > 11){date[k] = dM+1-12; ts.m = date[k];}
 					}
 					if(format[k] === 'a') {

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -127,7 +127,7 @@ $.extend($.jgrid,{
 						if(dM !== -1 && dM < 12){date[k] = dM+1; ts.m = date[k];}
 					}
 					if(format[k] === 'F') {
-						dM = $.inArray(date[k],opts.monthNames);
+						dM = $.inArray(date[k],opts.monthNames,12);
 						if(dM !== -1 && dM > 11){date[k] = dM+1-12; ts.m = date[k];}
 					}
 					if(format[k] === 'a') {


### PR DESCRIPTION
Fixes issue with parsing May in english when data contains full names of months. Also applies to May and some other months in other languages.
