### PR TITLE
Deleted extra comma from Chinese translate

### DIFF
--- a/js/i18n/grid.locale-cn.js
+++ b/js/i18n/grid.locale-cn.js
@@ -20,7 +20,7 @@ $.extend($.jgrid,{
         Find: "查找",
         Reset: "重置",
         odata: [{ oper:'eq', text:'等于\u3000\u3000'},{ oper:'ne', text:'不等\u3000\u3000'},{ oper:'lt', text:'小于\u3000\u3000'},{ oper:'le', text:'小于等于'},{ oper:'gt', text:'大于\u3000\u3000'},{ oper:'ge', text:'大于等于'},{ oper:'bw', text:'开始于'},{ oper:'bn', text:'不开始于'},{ oper:'in', text:'属于\u3000\u3000'},{ oper:'ni', text:'不属于'},{ oper:'ew', text:'结束于'},{ oper:'en', text:'不结束于'},{ oper:'cn', text:'包含\u3000\u3000'},{ oper:'nc', text:'不包含'}],
-        groupOps: [ { op: "AND", text: "所有" },    { op: "OR",  text: "任一" } ],
+        groupOps: [ { op: "AND", text: "所有" },    { op: "OR",  text: "任一" } ]
     },
     edit : {
         addCaption: "添加记录",


### PR DESCRIPTION
It's important for IE(v_v), please merge and release new version, sorry for it.

And the **js/i18n/grid.locale-cn.js** in archive file from [Download](http://www.trirand.com/blog/?page_id=6) page isn't the lastest, please check it.

![screenshot_5_22_13_8_14_pm](https://f.cloud.github.com/assets/1219399/548044/32d39188-c2d9-11e2-985d-fdd8a6343574.png)
