### PR TITLE
scope the textfields/select boxes with gs_gridname_fieldname rather than gs_ fieldname this was causing problems with multiple grids withs column name

### DIFF
--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -3989,7 +3989,7 @@ $.jgrid.extend({
 			var triggerToolbar = function() {
 				var sdata={}, j=0, v, nm, sopt={},so;
 				$.each($t.p.colModel,function(){
-					var $elem = $("#gs_"+$.jgrid.jqID(this.name), (this.frozen===true && $t.p.frozenColumns === true) ?  $t.grid.fhDiv : $t.grid.hDiv);
+					var $elem = $("#gs_" +$t.id + "_" + $.jgrid.jqID(this.name), (this.frozen===true && $t.p.frozenColumns === true) ?  $t.grid.fhDiv : $t.grid.hDiv);
 					nm = this.index || this.name;
 					if(p.searchOperators ) {
 						so = $elem.parent().prev().children("a").attr("soper") || p.defaultSearch;
@@ -4045,7 +4045,7 @@ $.jgrid.extend({
 				var sdata={}, j=0, nm;
 				trigger = (typeof trigger !== 'boolean') ? true : trigger;
 				$.each($t.p.colModel,function(){
-					var v, $elem = $("#gs_"+$.jgrid.jqID(this.name),(this.frozen===true && $t.p.frozenColumns === true) ?  $t.grid.fhDiv : $t.grid.hDiv);
+					var v, $elem = $("#gs_" +$t.id + "_" + $.jgrid.jqID(this.name),(this.frozen===true && $t.p.frozenColumns === true) ?  $t.grid.fhDiv : $t.grid.hDiv);
 					if(this.searchoptions && this.searchoptions.defaultValue !== undefined) { v = this.searchoptions.defaultValue; }
 					nm = this.index || this.name;
 					switch (this.stype) {
@@ -4234,7 +4234,7 @@ $.jgrid.extend({
 										$(self).append(stbl);
 									}
 									if(soptions.defaultValue !== undefined) { $("select",self).val(soptions.defaultValue); }
-									$("select",self).attr({name:cm.index || cm.name, id: "gs_"+cm.name});
+									$("select",self).attr({name:cm.index || cm.name, id: "gs_" +$t.id + "_" + cm.name});
 									if(soptions.attr) {$("select",self).attr(soptions.attr);}
 									$("select",self).css({width: "100%"});
 									// preserve autoserch
@@ -4262,7 +4262,7 @@ $.jgrid.extend({
 							if (oSv) {	
 								var elem = document.createElement("select");
 								elem.style.width = "100%";
-								$(elem).attr({name:cm.index || cm.name, id: "gs_"+cm.name});
+								$(elem).attr({name:cm.index || cm.name, id: "gs_" +$t.id + "_" + cm.name});
 								var sv, ov, key, k;
 								if(typeof oSv === "string") {
 									so = oSv.split(delim);
@@ -4298,7 +4298,7 @@ $.jgrid.extend({
 					case "text":
 						var df = soptions.defaultValue !== undefined ? soptions.defaultValue: "";
 
-						$("td:eq(1)",stbl).append("<input type='text' style='width:100%;padding:0px;' name='"+(cm.index || cm.name)+"' id='gs_"+cm.name+"' value='"+df+"'/>");
+						$("td:eq(1)",stbl).append("<input type='text' style='width:100%;padding:0px;' name='"+(cm.index || cm.name)+"' id='gs_"  +$t.id + "_" + cm.name+"' value='"+df+"'/>");
 						$(thd).append(stbl);
 
 						if(soptions.attr) {$("input",thd).attr(soptions.attr);}
@@ -4336,7 +4336,7 @@ $.jgrid.extend({
 						}
 						break;
 					case "custom":
-						$("td:eq(1)",stbl).append("<span style='width:95%;padding:0px;' name='"+(cm.index || cm.name)+"' id='gs_"+cm.name+"'/>");
+						$("td:eq(1)",stbl).append("<span style='width:95%;padding:0px;' name='"+(cm.index || cm.name)+"' id='gs_" + $t.id + "_" + cm.name+"'/>");
 						$(thd).append(stbl);
 						try {
 							if($.isFunction(soptions.custom_element)) {


### PR DESCRIPTION
Datepickers on toolbar filter were getting created as gs_FieldName but if if we use 2 or more grids on the same page the date picker after selection of date would point to the first date picker. scoping with grid id fixies the problem

Grid A - contains e.g column name "DueDate"
GridB also has a column "DueDate"

Now with this code change it should be gs_GridA_DueDate and gs_GridB_DueDate
Previously it was gs_DueDate for GridA and gs_DueDate for GridB and datepickers if attached on both grid, the date picker on GridB, the date was getting selected in GridA because of scope problem.
