### PR TITLE
tables from custom data formatters in frozen columns were getting truncated

### DIFF
--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -916,8 +916,8 @@ $.jgrid.extend({
 					$("#"+$.jgrid.jqID($t.p.id)+"_frozen").remove();
 					$($t.grid.fbDiv).height($($t.grid.bDiv).height()-16);
 					var btbl = $("#"+$.jgrid.jqID($t.p.id)).clone(true);
-					$("tr",btbl).each(function(){
-						$("td:gt("+maxfrozen+")",this).remove();
+					$("tr.jqgrow",btbl).each(function(){
+						$("td[role=gridcell]:gt("+maxfrozen+")",this).remove();
 					});
 
 					$(btbl).width(1).attr("id",$t.p.id+"_frozen");


### PR DESCRIPTION
Simply added .jqgrow and [role=gridcell] to a selector.

I had a formatter that was returning floating divs. Turns out IE couldn't handle them, so I dumbed it down to a one-row table. That's where this bug got me, but it was a simple enough fix. All but the first cell of my subtable was being removed from the DOM.
