### PR TITLE
Correction from last pull request

### DIFF
--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -916,7 +916,7 @@ $.jgrid.extend({
 					$("#"+$.jgrid.jqID($t.p.id)+"_frozen").remove();
 					$($t.grid.fbDiv).height($($t.grid.bDiv).height()-16);
 					var btbl = $("#"+$.jgrid.jqID($t.p.id)).clone(true);
-					$("tr.jqgrow",btbl).each(function(){
+					$("tr[role=row]",btbl).each(function(){
 						$("td[role=gridcell]:gt("+maxfrozen+")",this).remove();
 					});
 


### PR DESCRIPTION
this pull request was merged in today: https://github.com/tonytomov/jqGrid/pull/480

However I must swallow my pride and acknowledge I was not thorough and broke hovers on non-frozen rows. I tried to make the selector as strict as possible and overdid it, leaving frozen column headers in place. If this hasn't been noticed and solved already, here is the fix. 

Just changed .jqgrow to [role=row] since this will catch both .jqgrow and .jqgfirstrow which was the _full_ responsibility of the selector before I messed with it.
