### PR TITLE
Re-added support for restoreAfterError and mtype to editRow

### DIFF
--- a/js/grid.inlinedit.js
+++ b/js/grid.inlinedit.js
@@ -13,7 +13,7 @@
 $.jgrid.inlineEdit = $.jgrid.inlineEdit || {};
 $.jgrid.extend({
 //Editing
-	editRow : function(rowid,keys,oneditfunc,successfunc, url, extraparam, aftersavefunc,errorfunc, afterrestorefunc) {
+	editRow : function(rowid,keys,oneditfunc,successfunc, url, extraparam, aftersavefunc,errorfunc, afterrestorefunc, restoreAfterError, mtype) {
 		// Compatible mode old versions
 		var o={}, args = $.makeArray(arguments).slice(1);
 
@@ -29,8 +29,8 @@ $.jgrid.extend({
 			if ($.isFunction(errorfunc)) { o.errorfunc = errorfunc; }
 			if ($.isFunction(afterrestorefunc)) { o.afterrestorefunc = afterrestorefunc; }
 			// last two not as param, but as object (sorry)
-			//if (restoreAfterError !== undefined) { o.restoreAfterError = restoreAfterError; }
-			//if (mtype !== undefined) { o.mtype = mtype || "POST"; }			
+			if (restoreAfterError !== undefined) { o.restoreAfterError = restoreAfterError; }
+			if (mtype !== undefined) { o.mtype = mtype || "POST"; }			
 		}
 		o = $.extend(true, {
 			keys : false,

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -9181,7 +9181,7 @@ $.jgrid.extend({
 $.jgrid.inlineEdit = $.jgrid.inlineEdit || {};
 $.jgrid.extend({
 //Editing
-	editRow : function(rowid,keys,oneditfunc,successfunc, url, extraparam, aftersavefunc,errorfunc, afterrestorefunc) {
+	editRow : function(rowid,keys,oneditfunc,successfunc, url, extraparam, aftersavefunc,errorfunc, afterrestorefunc, restoreAfterError, mtype) {
 		// Compatible mode old versions
 		var o={}, args = $.makeArray(arguments).slice(1);
 
@@ -9197,8 +9197,8 @@ $.jgrid.extend({
 			if ($.isFunction(errorfunc)) { o.errorfunc = errorfunc; }
 			if ($.isFunction(afterrestorefunc)) { o.afterrestorefunc = afterrestorefunc; }
 			// last two not as param, but as object (sorry)
-			//if (restoreAfterError !== undefined) { o.restoreAfterError = restoreAfterError; }
-			//if (mtype !== undefined) { o.mtype = mtype || "POST"; }			
+			if (restoreAfterError !== undefined) { o.restoreAfterError = restoreAfterError; }
+			if (mtype !== undefined) { o.mtype = mtype || "POST"; }			
 		}
 		o = $.extend(true, {
 			keys : false,


### PR DESCRIPTION
Hello,

I re added support for the restoreAfterError and mtype parameters in the editRow method.
I'm not sure why they were removed in the first place, (see https://github.com/tonytomov/jqGrid/commit/48604395753a5750bcb457a9ca35cd72c3c63794).

Thanks!

