### PR TITLE
fix action buttons don't restore

### DIFF
--- a/js/grid.inlinedit.js
+++ b/js/grid.inlinedit.js
@@ -384,6 +384,11 @@ $.jgrid.extend({
 		// End compatible
 
 		return this.each(function(){
+			if ($(this).jqGrid('getGridParam', 'inlineEditOnlyOne') === true) {
+				$(this).find("div.ui-inline-edit,div.ui-inline-del").show();
+				$(this).find("div.ui-inline-save,div.ui-inline-cancel").hide();
+			}
+			
 			var $t= this, fr, ind, ares={}, k;
 			if (!$t.grid ) { return; }
 			ind = $($t).jqGrid("getInd",rowid,true);


### PR DESCRIPTION
Issue #490

Fix restore action buttons not working when editing one line at a time.
