### PR TITLE
Issue #493 fix idPrefix showing on column after save inline edit

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1098,21 +1098,20 @@ $.fn.jqGrid = function( pin ) {
 			return val == null || val === "" ? "&#160;" : (ts.p.autoencode ? $.jgrid.htmlEncode(val) : String(val));
 		},
 		formatter = function (rowId, cellval , colpos, rwdat, _act){
-			var cm = ts.p.colModel[colpos],v;
+			var cm = ts.p.colModel[colpos];
 			if(cm.formatter !== undefined) {
 				rowId = String(ts.p.idPrefix) !== "" ? $.jgrid.stripPref(ts.p.idPrefix, rowId) : rowId;
 				var opts= {rowId: rowId, colModel:cm, gid:ts.p.id, pos:colpos };
 				if($.isFunction( cm.formatter ) ) {
-					v = cm.formatter.call(ts,cellval,opts,rwdat,_act);
+					return cm.formatter.call(ts,cellval,opts,rwdat,_act);
 				} else if($.fmatter){
-					v = $.fn.fmatter.call(ts,cm.formatter,cellval,opts,rwdat,_act);
-				} else {
-					v = cellVal(cellval);
+					return $.fn.fmatter.call(ts,cm.formatter,cellval,opts,rwdat,_act);
 				}
-			} else {
-				v = cellVal(cellval);
+			} else if (cm.name === ts.p.jsonReader.id) {
+			    return String(ts.p.idPrefix) !== "" ? $.jgrid.stripPref(ts.p.idPrefix, rowId) : rowId;
 			}
-			return v;
+		
+			return cellVal(cellval);
 		},
 		addCell = function(rowId,cell,pos,irow, srvr, rdata) {
 			var v,prp;


### PR DESCRIPTION
Issue #493

problem:

idPrefix is showing on 'id' column after save a row with inline edit

fix:

If the column name is equal to the jsonReader 'id' property then the formatter function strip the idPrefix.

If a formatter is defined in the colModel, it will execute and the strip will not affect.

other action :

clean messy code
