### PR TITLE
Fix searchOperators toolbar (checkbox and select) + cleanup + set default css

### DIFF
--- a/css/ui.jqgrid.css
+++ b/css/ui.jqgrid.css
@@ -165,3 +165,4 @@ tr.ui-search-toolbar select {margin: 1px 0 0 0}
     box-sizing: border-box;
 }
 a.g-menu-item, a.soptclass, a.clearsearchclass { cursor: pointer; padding-right: 0.3em;padding-left: 0.3em;}
+

--- a/css/ui.jqgrid.css
+++ b/css/ui.jqgrid.css
@@ -1,6 +1,11 @@
+/*init*/
+.ui-jqgrid * {padding: 0;}
+.uijqgrid th, .ui-jqgrid td{
+    vertical-align: middle;
+}
 /*Grid*/
 .ui-jqgrid {position: relative;}
-.ui-jqgrid .ui-jqgrid-view {position: relative;left:0; top: 0; padding: 0; font-size:11px;}
+.ui-jqgrid > .ui-jqgrid-view {left:0; top: 0; padding: 0; font-size:11px;}
 /* caption*/
 .ui-jqgrid .ui-jqgrid-titlebar {padding: .3em .2em .2em .3em; position: relative; border-left: 0 none;border-right: 0 none; border-top: 0 none;}
 .ui-jqgrid .ui-jqgrid-title { float: left; margin: .1em 0 .2em; }
@@ -84,7 +89,7 @@ tr.ui-search-toolbar select {margin: 1px 0 0 0}
 * .jqgrid-overlay iframe {position:absolute;top:0;left:0;z-index:-1;width: expression(this.parentNode.offsetWidth+'px');height: expression(this.parentNode.offsetHeight+'px');}
 /* end loading div */
 /* toolbar */
-.ui-jqgrid .ui-userdata {border-left: 0 none;    border-right: 0 none;	height : 21px;overflow: hidden;	}
+.ui-jqgrid .ui-userdata {border-left: 0 none;    border-right: 0 none;    height : 21px;overflow: hidden;	}
 /*Modal Window */
 .ui-jqdialog { display: none; width: 300px; position: absolute; padding: .2em; font-size:11px; overflow:visible;}
 .ui-jqdialog .ui-jqdialog-titlebar { padding: .3em .2em; position: relative;  }
@@ -147,14 +152,16 @@ tr.ui-search-toolbar select {margin: 1px 0 0 0}
 
 /* Toolbar Search Menu */
 .ui-search-menu { position: absolute; padding: 2px 5px;}
-.ui-jqgrid .ui-search-table { padding: 0px 0px; border: 0px none; height:20px; width:100%;}
-.ui-jqgrid .ui-search-table .ui-search-oper { width:20px; }
-a.g-menu-item, a.soptclass, a.clearsearchclass { cursor: pointer; }
-.ui-jqgrid .ui-search-table .ui-search-input>input,
-.ui-jqgrid .ui-search-table .ui-search-input>select
-{
+.ui-jqgrid tr.ui-search-toolbar .ui-search-oper { width:20px; padding-right: 0.5em;}
+.ui-jqgrid tr.ui-search-toolbar li{
+    display:  table-cell;
+    vertical-align: bottom;
+}
+.ui-jqgrid tr.ui-search-toolbar input, .ui-jqgrid tr.ui-search-toolbar select{
+    width:100%;
     display: block;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
-} 
+}
+a.g-menu-item, a.soptclass, a.clearsearchclass { cursor: pointer; padding-right: 0.3em;padding-left: 0.3em;}

--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1098,21 +1098,20 @@ $.fn.jqGrid = function( pin ) {
 			return val == null || val === "" ? "&#160;" : (ts.p.autoencode ? $.jgrid.htmlEncode(val) : String(val));
 		},
 		formatter = function (rowId, cellval , colpos, rwdat, _act){
-			var cm = ts.p.colModel[colpos],v;
+			var cm = ts.p.colModel[colpos];
 			if(cm.formatter !== undefined) {
 				rowId = String(ts.p.idPrefix) !== "" ? $.jgrid.stripPref(ts.p.idPrefix, rowId) : rowId;
 				var opts= {rowId: rowId, colModel:cm, gid:ts.p.id, pos:colpos };
 				if($.isFunction( cm.formatter ) ) {
-					v = cm.formatter.call(ts,cellval,opts,rwdat,_act);
+					return cm.formatter.call(ts,cellval,opts,rwdat,_act);
 				} else if($.fmatter){
-					v = $.fn.fmatter.call(ts,cm.formatter,cellval,opts,rwdat,_act);
-				} else {
-					v = cellVal(cellval);
+					return $.fn.fmatter.call(ts,cm.formatter,cellval,opts,rwdat,_act);
 				}
-			} else {
-				v = cellVal(cellval);
+			} else if (cm.name === ts.p.jsonReader.id) {
+			    return String(ts.p.idPrefix) !== "" ? $.jgrid.stripPref(ts.p.idPrefix, rowId) : rowId;
 			}
-			return v;
+		
+			return cellVal(cellval);
 		},
 		addCell = function(rowId,cell,pos,irow, srvr, rdata) {
 			var v,prp;

--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -392,14 +392,13 @@ $.jgrid.extend({
 			var timeoutHnd;
 			$.each($t.p.colModel,function(ci){
 				var cm=this, soptions, surl, self, select = "", sot="=", so, i,
-				th = $("<th role='columnheader' class='ui-state-default ui-th-column ui-th-"+$t.p.direction+"'></th>"),
-				thd = $("<div style='position:relative;height:100%;padding-right:0.3em;padding-left:0.3em;'></div>"),
-				stbl = $("<table class='ui-search-table' cellspacing='0'><tr><td class='ui-search-input'></td><td class='ui-search-clear'></td></tr></table>");
+				th = $("<th role='columnheader' class='ui-state-default ui-th-column ui-th-"+$t.p.direction+"'></th>");
 				if(this.hidden===true) { $(th).css("display","none");}
 				this.search = this.search === false ? false : true;
-				if(this.stype === undefined) {this.stype='text';}
 				soptions = $.extend({},this.searchoptions || {});
 				if(this.search){
+					var stbl = $("<ul class='ui-search-box'><li class='ui-search-input'></li><li class='ui-search-clear'></li></ul>");
+					if(this.stype === undefined) {this.stype='text';}
 					if(p.searchOperators && cm.edittype !== 'checkbox') {
 						so  = (soptions.sopt) ? soptions.sopt[0] : cm.stype==='select' ?  'eq' : p.defaultSearch;
 						for(i = 0;i<p.odata.length;i++) {
@@ -408,16 +407,16 @@ $.jgrid.extend({
 								break;
 							}
 						}
-						var st = soptions.searchtitle != null ? soptions.searchtitle : p.operandTitle;
-						select = "<td class='ui-search-oper' colindex='"+ci+"'><a title='"+st+"' style='padding-right: 0.5em;' soper='"+so+"' class='soptclass' colname='"+this.name+"'>"+sot+"</a></td>";
-						$("tr:eq(0)",stbl).prepend(select);
+						var st = soptions.searchtitle !== null ? soptions.searchtitle : p.operandTitle;
+						select = "<li class='ui-search-oper' colindex='"+ci+"'><a title='"+st+"' soper='"+so+"' class='soptclass' colname='"+this.name+"'>"+sot+"</a></li>";
+						$(stbl).prepend(select);
 					}
-					
+			
 					if(soptions.clearSearch === undefined) {
 						soptions.clearSearch = true;
 					}
 					if(soptions.clearSearch && cm.stype !== 'select') {
-						$("td:eq(2)",stbl).append("<a title='Clear Search Value' style='padding-right: 0.3em;padding-left: 0.3em;' class='clearsearchclass'>x</a>");
+						$("li:eq(2)",stbl).append("<a title='Clear Search Value' class='clearsearchclass'>x</a>");
 					}
 					switch (this.stype)
 					{
@@ -426,7 +425,7 @@ $.jgrid.extend({
 						if(surl) {
 							// data returned should have already constructed html select
 							// primitive jQuery load
-							self = thd;
+							self = th;
 							$.ajax($.extend({
 								url: surl,
 								dataType: "html",
@@ -434,18 +433,18 @@ $.jgrid.extend({
 									if(soptions.buildSelect !== undefined) {
 										var d = soptions.buildSelect(res);
 										if (d) {
-											$("td:eq(1)",stbl).append(d);
+											$("li:eq(1)",stbl).append(d);
 											$(self).append(stbl);
 										}
 									} else {
-										$("td:eq(1)",stbl).append(res);
+										$("li:eq(1)",stbl).append(res);
 										$(self).append(stbl);
 									}
 									if(soptions.defaultValue !== undefined) { $("select",self).val(soptions.defaultValue); }
 									$("select",self).attr({name:cm.index || cm.name, id: "gs_"+cm.name});
 									if(soptions.attr) {$("select",self).attr(soptions.attr);}
 									$("select",self).css({width: "100%"});
-									// preserve autoserch
+									// preserve autosearch
 									$.jgrid.bindEv.call($t, $("select",self)[0], soptions);
 									if(p.autosearch===true){
 										$("select",self).change(function(){
@@ -459,15 +458,15 @@ $.jgrid.extend({
 						} else {
 							var oSv, sep, delim;
 							if(cm.searchoptions) {
-								oSv = cm.searchoptions.value === undefined ? "" : cm.searchoptions.value;
+								oSv = cm.searchoptions.value === undefined ? false : cm.searchoptions.value;
 								sep = cm.searchoptions.separator === undefined ? ":" : cm.searchoptions.separator;
 								delim = cm.searchoptions.delimiter === undefined ? ";" : cm.searchoptions.delimiter;
 							} else if(cm.editoptions) {
-								oSv = cm.editoptions.value === undefined ? "" : cm.editoptions.value;
+								oSv = cm.editoptions.value === undefined ? false : cm.editoptions.value;
 								sep = cm.editoptions.separator === undefined ? ":" : cm.editoptions.separator;
 								delim = cm.editoptions.delimiter === undefined ? ";" : cm.editoptions.delimiter;
 							}
-							if (oSv) {	
+							if (oSv !== false) {	
 								var elem = document.createElement("select");
 								elem.style.width = "100%";
 								$(elem).attr({name:cm.index || cm.name, id: "gs_"+cm.name});
@@ -492,8 +491,8 @@ $.jgrid.extend({
 								if(soptions.defaultValue !== undefined) { $(elem).val(soptions.defaultValue); }
 								if(soptions.attr) {$(elem).attr(soptions.attr);}
 								$.jgrid.bindEv.call($t, elem , soptions);
-								$("td:eq(1)",stbl).append( elem );
-								$(thd).append(stbl);
+								$("li:eq(1)",stbl).append( elem );
+								$(th).append(stbl);
 								if(p.autosearch===true){
 									$(elem).change(function(){
 										triggerToolbar();
@@ -506,14 +505,14 @@ $.jgrid.extend({
 					case "text":
 						var df = soptions.defaultValue !== undefined ? soptions.defaultValue: "";
 
-						$("td:eq(1)",stbl).append("<input type='text' style='width:100%;padding:0px;' name='"+(cm.index || cm.name)+"' id='gs_"+cm.name+"' value='"+df+"'/>");
-						$(thd).append(stbl);
+						$("li:eq(1)",stbl).append("<input type='text' name='"+(cm.index || cm.name)+"' id='gs_"+cm.name+"' value='"+df+"'/>");
+						$(th).append(stbl);
 
-						if(soptions.attr) {$("input",thd).attr(soptions.attr);}
-						$.jgrid.bindEv.call($t, $("input",thd)[0], soptions);
+						if(soptions.attr) {$("input",th).attr(soptions.attr);}
+						$.jgrid.bindEv.call($t, $("input",th)[0], soptions);
 						if(p.autosearch===true){
 							if(p.searchOnEnter) {
-								$("input",thd).keypress(function(e){
+								$("input",th).keypress(function(e){
 									var key = e.charCode || e.keyCode || 0;
 									if(key === 13){
 										triggerToolbar();
@@ -522,7 +521,7 @@ $.jgrid.extend({
 									return this;
 								});
 							} else {
-								$("input",thd).keydown(function(e){
+								$("input",th).keydown(function(e){
 									var key = e.which;
 									switch (key) {
 										case 13:
@@ -544,14 +543,14 @@ $.jgrid.extend({
 						}
 						break;
 					case "custom":
-						$("td:eq(1)",stbl).append("<span style='width:95%;padding:0px;' name='"+(cm.index || cm.name)+"' id='gs_"+cm.name+"'/>");
-						$(thd).append(stbl);
+						$("li:eq(1)",stbl).append("<span style='width:95%;padding:0px;' name='"+(cm.index || cm.name)+"' id='gs_"+cm.name+"'/>");
+						$(th).append(stbl);
 						try {
 							if($.isFunction(soptions.custom_element)) {
 								var celm = soptions.custom_element.call($t,soptions.defaultValue !== undefined ? soptions.defaultValue: "",soptions);
 								if(celm) {
 									celm = $(celm).addClass("customelement");
-									$(thd).find(">span").append(celm);
+									$(th).find(">span").append(celm);
 								} else {
 									throw "e2";
 								}
@@ -566,10 +565,10 @@ $.jgrid.extend({
 						break;
 					}
 				}
-				$(th).append(thd);
+				$(th).append(th);
 				$(tr).append(th);
 				if(!p.searchOperators) {
-					$("td:eq(0)",stbl).hide();
+					$("li:eq(0)",stbl).hide();
 				}
 			});
 			$("table thead",$t.grid.hDiv).append(tr);

--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -472,9 +472,7 @@ $.jgrid.extend({
 								$(elem).attr({name:cm.index || cm.name, id: "gs_"+cm.name});
 								var sv, ov, key, k;
 								if(typeof oSv === "string") {
-									if(oSv.charAt( oSv.length-1 ) == delim){
-									    oSv = oSv.substr(0, oSv.length-1);
-									}
+									oSv = oSv.charAt( oSv.length-1 ) === delim ? oSv.substr(0, oSv.length-1) : oSv ;
 									so = oSv.split(delim);
 									for(k=0; k<so.length;k++){
 										sv = so[k].split(sep);

--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -472,6 +472,9 @@ $.jgrid.extend({
 								$(elem).attr({name:cm.index || cm.name, id: "gs_"+cm.name});
 								var sv, ov, key, k;
 								if(typeof oSv === "string") {
+									if(oSv.charAt( oSv.length-1 ) == ";"){
+									    oSv = oSv.substr(0, oSv.length-1);
+									}
 									so = oSv.split(delim);
 									for(k=0; k<so.length;k++){
 										sv = so[k].split(sep);

--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -472,7 +472,7 @@ $.jgrid.extend({
 								$(elem).attr({name:cm.index || cm.name, id: "gs_"+cm.name});
 								var sv, ov, key, k;
 								if(typeof oSv === "string") {
-									if(oSv.charAt( oSv.length-1 ) == ";"){
+									if(oSv.charAt( oSv.length-1 ) == delim){
 									    oSv = oSv.substr(0, oSv.length-1);
 									}
 									so = oSv.split(delim);

--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -394,13 +394,13 @@ $.jgrid.extend({
 				var cm=this, soptions, surl, self, select = "", sot="=", so, i,
 				th = $("<th role='columnheader' class='ui-state-default ui-th-column ui-th-"+$t.p.direction+"'></th>"),
 				thd = $("<div style='position:relative;height:100%;padding-right:0.3em;padding-left:0.3em;'></div>"),
-				stbl = $("<table class='ui-search-table' cellspacing='0'><tr><td class='ui-search-oper'></td><td class='ui-search-input'></td><td class='ui-search-clear'></td></tr></table>");
+				stbl = $("<table class='ui-search-table' cellspacing='0'><tr><td class='ui-search-input'></td><td class='ui-search-clear'></td></tr></table>");
 				if(this.hidden===true) { $(th).css("display","none");}
 				this.search = this.search === false ? false : true;
 				if(this.stype === undefined) {this.stype='text';}
 				soptions = $.extend({},this.searchoptions || {});
 				if(this.search){
-					if(p.searchOperators) {
+					if(p.searchOperators && cm.edittype !== 'checkbox') {
 						so  = (soptions.sopt) ? soptions.sopt[0] : cm.stype==='select' ?  'eq' : p.defaultSearch;
 						for(i = 0;i<p.odata.length;i++) {
 							if(p.odata[i].oper === so) {
@@ -409,13 +409,14 @@ $.jgrid.extend({
 							}
 						}
 						var st = soptions.searchtitle != null ? soptions.searchtitle : p.operandTitle;
-						select = "<a title='"+st+"' style='padding-right: 0.5em;' soper='"+so+"' class='soptclass' colname='"+this.name+"'>"+sot+"</a>";
+						select = "<td class='ui-search-oper' colindex='"+ci+"'><a title='"+st+"' style='padding-right: 0.5em;' soper='"+so+"' class='soptclass' colname='"+this.name+"'>"+sot+"</a></td>";
+						$("tr:eq(0)",stbl).prepend(select);
 					}
-					$("td:eq(0)",stbl).attr("colindex",ci).append(select);
+					
 					if(soptions.clearSearch === undefined) {
 						soptions.clearSearch = true;
 					}
-					if(soptions.clearSearch) {
+					if(soptions.clearSearch && cm.stype !== 'select') {
 						$("td:eq(2)",stbl).append("<a title='Clear Search Value' style='padding-right: 0.3em;padding-left: 0.3em;' class='clearsearchclass'>x</a>");
 					}
 					switch (this.stype)

--- a/js/grid.inlinedit.js
+++ b/js/grid.inlinedit.js
@@ -384,6 +384,11 @@ $.jgrid.extend({
 		// End compatible
 
 		return this.each(function(){
+			if ($(this).jqGrid('getGridParam', 'inlineEditOnlyOne') === true) {
+				$(this).find("div.ui-inline-edit,div.ui-inline-del").show();
+				$(this).find("div.ui-inline-save,div.ui-inline-cancel").hide();
+			}
+			
 			var $t= this, fr, ind, ares={}, k;
 			if (!$t.grid ) { return; }
 			ind = $($t).jqGrid("getInd",rowid,true);


### PR DESCRIPTION
The searchOperators are totally useless for checkbox. This commit avoid them for this case.

The clearSearch is useless for select since there is no multiselect  in search toolbae. This commit avoid it.

Also, it saves some width on these columns.

- remove search table and replace by ul.
- remove dirty style attributes (refacto in css)
- set defaults css to jqgrid elements
- strip last char of select values if string and end by ";" 
- some code cleanup