### PR TITLE
fixing resetting of selection and saved row if onPaging returns 'stop'

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2037,10 +2037,10 @@ $.fn.jqGrid = function( pin ) {
 			clearVals = function(onpaging){
 				var ret;
 				if ($.isFunction(ts.p.onPaging) ) { ret = ts.p.onPaging.call(ts,onpaging); }
+				if(ret==='stop') {return false;}
 				ts.p.selrow = null;
 				if(ts.p.multiselect) {ts.p.selarrrow =[]; setHeadCheckBox( false );}
 				ts.p.savedRow = [];
-				if(ret==='stop') {return false;}
 				return true;
 			};
 			pgid = pgid.substr(1);


### PR DESCRIPTION
Hello Tony,

I suggest to change the order of some lines to prevent resetting of `selarrrow`, `selrow` and `savedRow` if `onPaging` callback returns `'stop'`. More details about the problem are in [the answer](http://stackoverflow.com/a/17620025/315935).

Best regards
Oleg
