### PR TITLE
Never ignore populate()

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1883,7 +1883,13 @@ $.fn.jqGrid = function( pin ) {
 			}
 		},
 		populate = function (npage) {
-			if(!ts.grid.hDiv.loading) {
+			if(ts.grid.hDiv.loading) {
+				clearTimeout(ts.grid.hDiv.populateTimeout);
+				setTimeout(
+					function() { populate(npage); },
+					200
+				);
+			} else {
 				var pvis = ts.p.scroll && npage === false,
 				prm = {}, dt, dstr, pN=ts.p.prmNames;
 				if(ts.p.page <=0) { ts.p.page = Math.min(1,ts.p.lastpage); }

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -1885,7 +1885,13 @@ $.fn.jqGrid = function( pin ) {
 			}
 		},
 		populate = function (npage) {
-			if(!ts.grid.hDiv.loading) {
+			if(ts.grid.hDiv.loading) {
+				clearTimeout(ts.grid.hDiv.populateTimeout);
+				setTimeout(
+					function() { populate(npage); },
+					200
+				);
+			} else {
 				var pvis = ts.p.scroll && npage === false,
 				prm = {}, dt, dstr, pN=ts.p.prmNames;
 				if(ts.p.page <=0) { ts.p.page = 1; }


### PR DESCRIPTION
If populating is requested while other populating is in progress, don't
ignore it, but populate after current one ends.

Consider scenario:
1. user starts typing into filter toolbar: "foo"
2. grid starts refreshing via ajax
3. user keeps typing: "foobar", but triggered reload is ignored, as grid is already loading
4. grid loads and is incorrectly filtered
