### PR TITLE
Option to keep filters, when refreshing

### DIFF
--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -1943,7 +1943,7 @@ $.jgrid.extend({
 					.click(function(){
 						if (!$(this).hasClass('ui-state-disabled')) {
 							if($.isFunction(o.beforeRefresh)) {o.beforeRefresh.call($t);}
-							if(o.keepFiltersOnRefresh) {
+							if(!$t.p.keepFiltersOnRefresh) {
 								$t.p.search = false;
 								try {
 									var gID = $t.p.id;

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -9011,7 +9011,7 @@ $.jgrid.extend({
 					.click(function(){
 						if (!$(this).hasClass('ui-state-disabled')) {
 							if($.isFunction(o.beforeRefresh)) {o.beforeRefresh.call($t);}
-							if(o.keepFiltersOnRefresh) {
+							if(!$t.p.keepFiltersOnRefresh) {
 								$t.p.search = false;
 								try {
 									var gID = $t.p.id;


### PR DESCRIPTION
Enabling option `keepFiltersOnRefresh` prevents filters from being reset before a refresh.
