### PR TITLE
Make sure loading message is always visible

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1854,18 +1854,33 @@ $.fn.jqGrid = function( pin ) {
 			$(ts).triggerHandler("jqGridAfterGridComplete");
 		},
 		beginReq = function() {
+			var loadDiv = $("#load_"+$.jgrid.jqID(ts.p.id)),
+				offsetParent,
+				top,
+				scrollTop = $(window).scrollTop();
 			ts.grid.hDiv.loading = true;
 			if(ts.p.hiddengrid) { return;}
 			switch(ts.p.loadui) {
 				case "disable":
 					break;
 				case "enable":
-					$("#load_"+$.jgrid.jqID(ts.p.id)).show();
+					loadDiv.show();
 					break;
 				case "block":
 					$("#lui_"+$.jgrid.jqID(ts.p.id)).show();
-					$("#load_"+$.jgrid.jqID(ts.p.id)).show();
+					loadDiv.show();
 					break;
+			}
+			if (loadDiv.is(':visible')) {
+				offsetParent = loadDiv.offsetParent();
+				loadDiv.css('top', '');
+				if (loadDiv.offset().top < scrollTop) {
+					top = Math.min(
+						10 + scrollTop - offsetParent.offset().top,
+						offsetParent.height() - loadDiv.height()
+					);
+					loadDiv.css('top', top + 'px');
+				}
 			}
 		},
 		endReq = function() {


### PR DESCRIPTION
In case of grids taller than browser window height, when using refresh
button on the bottom of the grid we could not see loading message, which
showed up on the top of the grid.