### PR TITLE
Fix for bug "Inline Navigator cancel after click pager"

### DIFF
--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -2110,6 +2110,7 @@ $.fn.jqGrid = function( pin ) {
 				}
 			});
 			$("#first"+$.jgrid.jqID(tp)+", #prev"+$.jgrid.jqID(tp)+", #next"+$.jgrid.jqID(tp)+", #last"+$.jgrid.jqID(tp)).click( function() {
+				if (!$(this).hasClass("ui-state-disabled")) {
 				var cp = intNum(ts.p.page,1),
 				last = intNum(ts.p.lastpage,1), selclick = false,
 				fp=true, pp=true, np=true,lp=true;
@@ -2126,6 +2127,8 @@ $.fn.jqGrid = function( pin ) {
 				if( this.id === 'last'+tp && lp) { ts.p.page=last; selclick=true;}
 				if(selclick) {
 					populate();
+				}
+				
 				}
 				return false;
 			});


### PR DESCRIPTION
Fix for:
https://github.com/tonytomov/jqGrid/issues/518
Grid with inlineNav.
Edit row (dont save) -> 
Click to disabled pager button "move to the first page" ->
Click to InlineNav cancel button ->
Error "Uncaught TypeError: Cannot read property 'id' of undefined" - savedRow now is empty. 
Also, reproduced in demos.
