### PR TITLE
Fix for "TypeError: ajaxso is undefined" in Single/Advanced searching

### DIFF
--- a/js/grid.filter.js
+++ b/js/grid.filter.js
@@ -358,7 +358,7 @@ $.fn.jqFilter = function( arg ) {
 						cm.searchoptions.size = 10;
 					}
 				}
-				var elm = $.jgrid.createEl.call($t, cm.inputtype,cm.searchoptions, "", true, that.p.ajaxSelectOptions, true);
+				var elm = $.jgrid.createEl.call($t, cm.inputtype,cm.searchoptions, "", true, that.p.ajaxSelectOptions || {}, true);
 				$(elm).addClass("input-elm");
 				//that.createElement(rule, "");
 
@@ -436,7 +436,7 @@ $.fn.jqFilter = function( arg ) {
 					cm.searchoptions.size = 10;
 				}
 			}
-			var ruleDataInput = $.jgrid.createEl.call($t, cm.inputtype,cm.searchoptions, rule.data, true, that.p.ajaxSelectOptions, true);
+			var ruleDataInput = $.jgrid.createEl.call($t, cm.inputtype,cm.searchoptions, rule.data, true, that.p.ajaxSelectOptions || {}, true);
 			if(rule.op === 'nu' || rule.op === 'nn') {
 				$(ruleDataInput).attr('readonly','true');
 				$(ruleDataInput).attr('disabled','true');


### PR DESCRIPTION
If one is using a `stype: 'select'`and `dataUrl` in case of Single or Advance searching scenario it leads to following exception:

> "TypeError: ajaxso is undefined"

on line

```
postData = options.postData || ajaxso.postData;
```

of grid.common.js
