### PR TITLE
Fixing usage of `formatDisplayField` and collapsing/expending behavior of multi-level groping

### DIFF
--- a/js/grid.grouping.js
+++ b/js/grid.grouping.js
@@ -175,8 +175,6 @@ $.jgrid.extend({
 			var $t = this,
 			grp = $t.p.groupingView,
 			strpos = hid.split('_'),
-			uidpos,
-			//uid = hid.substring(0,strpos+1),
 			num = parseInt(strpos[strpos.length-2], 10);
 			strpos.splice(strpos.length-2,2);
 			var uid = strpos.join("_"),
@@ -195,7 +193,7 @@ $.jgrid.extend({
 			},
 			itemGroupingLevel,
 			showData,
-			collapsed = false, tspan;
+			collapsed = false;
 			if( tarspan.hasClass(minus) ) {
 				if(grp.showSummaryOnHide) {
 					if(r){
@@ -235,7 +233,8 @@ $.jgrid.extend({
 						if (itemGroupingLevel !== undefined) {
 							if (itemGroupingLevel <= num) {
 								break;// next item of the same lever are found
-							} else if (itemGroupingLevel === num + 1) {
+							}
+							if (itemGroupingLevel === num + 1) {
 								$(r).show().find(">td>span."+"tree-wrap-"+$t.p.direction).removeClass(minus).addClass(plus);
 							}
 						} else if (showData) {


### PR DESCRIPTION
Hello Tony,

during writing [the answer](http://stackoverflow.com/a/19207377/315935) on the stackoverflow I fond some small bug in `formatDisplayField` (see the demo from [the answer](http://stackoverflow.com/a/16152739/315935)). Additionally I suggest to change the behavior of `groupCollapse:true` to that only top-level grouping headers are displayed. At the end the suggested changes modify `groupingToggle` so that only **the next** grouping sub-level will be displayed on expanding instead of displaying all sub-levels with all data currently.

[The demo](http://www.ok-soft-gmbh.com/jqGrid/ExpandingStateOfSubGroups.htm) demonstrates suggested changes. You can compare the same demo with the current jqGrid code [here](http://www.ok-soft-gmbh.com/jqGrid/ExpandingStateOfSubGroups0.htm).

Best regards
Oleg
