### PR TITLE
Fixing wrong left position of resizing partition

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -860,10 +860,11 @@ $.fn.jqGrid = function( pin ) {
 			cols:[],
 			footers: [],
 			dragStart: function(i,x,y) {
-				this.resizing = { idx: i, startX: x.clientX, sOL : x.clientX-6};
+				var gridLeftPos = $(this.bDiv).offset().left;
+				this.resizing = { idx: i, startX: x.clientX, sOL : x.clientX - gridLeftPos };
 				this.hDiv.style.cursor = "col-resize";
 				this.curGbox = $("#rs_m"+$.jgrid.jqID(p.id),"#gbox_"+$.jgrid.jqID(p.id));
-				this.curGbox.css({display:"block",left:x.clientX-6,top:y[1],height:y[2]});
+				this.curGbox.css({display:"block",left:x.clientX-gridLeftPos,top:y[1],height:y[2]});
 				$(ts).triggerHandler("jqGridResizeStart", [x, i]);
 				if($.isFunction(p.resizeStart)) { p.resizeStart.call(ts,x,i); }
 				document.onselectstart=function(){return false;};


### PR DESCRIPTION
Hello Tony,

the changes of `dragStart` in the last version of jqGrid (4.5.4) uses now `clientX` property of the mouse `mousedown` event. The calculation of `left` position of the div (`div.ui-jqgrid-resize-mark`) has wrong value. The div is the child of `gbox` (sibling of `ui-jqgrid-view`) which has `position:relative;`. So one have to use _relative_ position values for `left` and `top` CSS properties of `div.ui-jqgrid-resize-mark`. The suggested code uses `$(this.bDiv).offset().left` (the same as `$(this.bDiv).closest(".ui-jqgrid-view").offset().left`) instead on unclear constant `6` value from the current code of `dragStart`.

[The demo](http://www.ok-soft-gmbh.com/jqGrid/WrongPositionOfSeparaterBarDuringColumnResizing0.htm) uses

```
<div style="margin-left:20px">
  <table id="list"><tr><td></td></tr></table>
  <div id="pager"></div>
</div>
```

and it can be used to demonstrate that jqGrid 4.5.4 wrong calculate left position of resizing div.

[Another demo](http://www.ok-soft-gmbh.com/jqGrid/WrongPositionOfSeparaterBarDuringColumnResizing.htm) uses suggestions of the current pull request and it works correct.

Best regards
Oleg
