### PR TITLE
remove unneeded options which overwrites values from $.jgrid.inlineEdit

### DIFF
--- a/js/jquery.fmatter.js
+++ b/js/jquery.fmatter.js
@@ -263,18 +263,7 @@
 			cm = p.colModel[$.jgrid.getCellIndex(this)],
 			$actionsDiv = cm.frozen ? $("tr#"+rid+" td:eq("+$.jgrid.getCellIndex(this)+") > div",$grid) :$(this).parent(),
 			op = {
-				keys: false,
-				onEdit: null, 
-				onSuccess: null, 
-				afterSave: null,
-				onError: null,
-				afterRestore: null,
-				extraparam: {},
-				url: null,
-				restoreAfterError: true,
-				mtype: "POST",
-				delOptions: {},
-				editOptions: {}
+				extraparam: {}
 			},
 			saverow = function(rowid, res) {
 				if($.isFunction(op.afterSave)) { op.afterSave.call($t, rowid, res); }


### PR DESCRIPTION
Hello Tony,

current version of jqGrid has the following problem: no options from `$.jgrid.inlineEdit` will be used during inline editing with `formatter: "actions"`. The problem is that `editRow` and `saveRow` will be called with object parameter having `null` options. In the case `$.extend` (like [this one](https://github.com/tonytomov/jqGrid/blob/v4.5.4/js/grid.inlinedit.js#L145-L154)) overwrite all value of `$.jgrid.inlineEdit` with `null` or other values set [here](https://github.com/tonytomov/jqGrid/blob/v4.5.4/js/jquery.fmatter.js#L265-L278). I suggest remove the most properties of `op`. After that the variable `actop` will be initialized (see [here](https://github.com/tonytomov/jqGrid/blob/v4.5.4/js/jquery.fmatter.js#L302-L313)) with some `undefined` values, but all the values will be overwritten by `$.extend` at the beginning of  `editRow` or `saveRow` (like [this one](https://github.com/tonytomov/jqGrid/blob/v4.5.4/js/grid.inlinedit.js#L145-L154)).

Best regards
Oleg
