### PR TITLE
Bug fix for click event for subgrid expand being bound multiple times when virtual scrolling.

### DIFF
--- a/js/grid.subgrid.js
+++ b/js/grid.subgrid.js
@@ -88,7 +88,7 @@ addSubGrid : function( pos, sind ) {
 			ts.grid.hDiv.loading = false;
 			$("#load_"+$.jgrid.jqID(ts.p.id)).hide();
 			return false;
-		};
+		}; // here i made a change
 		var subGridJson = function(sjxml, sbid){
 			var tddiv,result,i,cur, sgmap,j,
 			dummy = $("<table cellspacing='0' cellpadding='0' border='0'><tbody></tbody></table>"),

--- a/js/grid.subgrid.js
+++ b/js/grid.subgrid.js
@@ -190,7 +190,7 @@ addSubGrid : function( pos, sind ) {
 		}
 		while(i < len) {
 			if($(ts.rows[i]).hasClass('jqgrow')) {
-				$(ts.rows[i].cells[pos]).bind('click', function() {
+				$(ts.rows[i].cells[pos]).unbind('click.toggle').bind('click.toggle', function() {
 					var tr = $(this).parent("tr")[0];
 					r = tr.nextSibling;
 					if($(this).hasClass("sgcollapsed")) {

--- a/js/grid.subgrid.js
+++ b/js/grid.subgrid.js
@@ -88,7 +88,7 @@ addSubGrid : function( pos, sind ) {
 			ts.grid.hDiv.loading = false;
 			$("#load_"+$.jgrid.jqID(ts.p.id)).hide();
 			return false;
-		}; // here i made a change
+		};
 		var subGridJson = function(sjxml, sbid){
 			var tddiv,result,i,cur, sgmap,j,
 			dummy = $("<table cellspacing='0' cellpadding='0' border='0'><tbody></tbody></table>"),

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -10555,7 +10555,7 @@ addSubGrid : function( pos, sind ) {
 		}
 		while(i < len) {
 			if($(ts.rows[i]).hasClass('jqgrow')) {
-				$(ts.rows[i].cells[pos]).bind('click', function() {
+                $(ts.rows[i].cells[pos]).unbind('click.toggle').bind('click.toggle', function () {
 					var tr = $(this).parent("tr")[0];
 					r = tr.nextSibling;
 					if($(this).hasClass("sgcollapsed")) {


### PR DESCRIPTION
When using virtual scrolling and subgrids, when scrolling down and the grid is adding new rows, i starts over at 1 and rebinds the click event for the expand button. This causes the click event to get fired multiple times (as many times as additional rows were added when scrolling, and if two times the expand happens, then the collapse happens and you never see the subgrid). Adding a simple unbind before binding will eliminate this, and allow the expand button to work properly.The "click" event was namespaced to eliminate future bugs if namespacing this event was used in the future.
