### PR TITLE
multi select box default seperator revision

### DIFF
--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -6071,9 +6071,10 @@ $.extend($.jgrid,{
 			case "select" :
 				elem = document.createElement("select");
 				elem.setAttribute("role","select");
-				var msl, ovm = [];
+				var msl, ovm = [], multiseparator;
 				if(options.multiple===true) {
 					msl = true;
+					multiseparator = options.multiseparator === undefined ? ",": options.multiseparator;
 					elem.multiple="multiple";
 					$(elem).attr("aria-multiselectable","true");
 				} else { msl = false; }
@@ -6103,7 +6104,6 @@ $.extend($.jgrid,{
 								setAttributes(elem, options, postData ? ['postData'] : undefined );
 								if(options.size === undefined) { options.size =  msl ? 3 : 1;}
 								if(msl) {
-									var multiseparator = options.multiseparator === undefined ? ",": options.multiseparator;
 									ovm = vl.split(multiseparator);
 									ovm = $.map(ovm,function(n){return $.trim(n);});
 								} else {
@@ -6130,7 +6130,7 @@ $.extend($.jgrid,{
 						options.size = msl ? 3 : 1;
 					}
 					if(msl) {
-						ovm = vl.split(",");
+						ovm = vl.split(multiseparator);
 						ovm = $.map(ovm,function(n){return $.trim(n);});
 					}
 					if(typeof options.value === 'function') { options.value = options.value(); }
@@ -9417,14 +9417,15 @@ $.jgrid.extend({
 								tmp2[nm] = $("select option:selected", this).text();
 							} else {
 								var sel = $("select",this), selectedText = [];
+								var multiseparator = cm.editoptions.multiseparator === undefined ? ",": cm.editoptions.multiseparator;
 								tmp[nm] = $(sel).val();
-								if(tmp[nm]) { tmp[nm]= tmp[nm].join(","); } else { tmp[nm] =""; }
+								if(tmp[nm]) { tmp[nm]= tmp[nm].join(multiseparator); } else { tmp[nm] =""; }
 								$("select option:selected",this).each(
 									function(i,selected){
 										selectedText[i] = $(selected).text();
 									}
 								);
-								tmp2[nm] = selectedText.join(",");
+								tmp2[nm] = selectedText.join(multiseparator);
 							}
 							if(cm.formatter && cm.formatter === 'select') { tmp2={}; }
 							break;

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -6103,7 +6103,8 @@ $.extend($.jgrid,{
 								setAttributes(elem, options, postData ? ['postData'] : undefined );
 								if(options.size === undefined) { options.size =  msl ? 3 : 1;}
 								if(msl) {
-									ovm = vl.split(",");
+									var multiseparator = options.multiseparator === undefined ? ",": options.multiseparator;
+									ovm = vl.split(multiseparator);
 									ovm = $.map(ovm,function(n){return $.trim(n);});
 								} else {
 									ovm[0] = $.trim(vl);


### PR DESCRIPTION
editoptions:{ 
    multiple:true, 
    size:3, 
    value: {S:'S', E:'E', T:'T'},
    multiseparator: " "
},

we can assign separator by using multiseparator now.
