### PR TITLE
Added support for csv export

### DIFF
--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -12130,7 +12130,9 @@ $.jgrid.extend({
             o = $.extend({
                 exptype : "xmlstring",
                 root: "grid",
-                ident: "\t"
+                ident: "\t",
+                separator: ";",
+                hideColumns: []
             }, o || {});
             var ret = null;
             this.each(function () {
@@ -12167,7 +12169,7 @@ $.jgrid.extend({
                         ret = "{"+ xmlJsonClass.toJson(gprm,o.root,o.ident,false)+"}";
                         if(gprm.postData.filters !== undefined) {
                             ret=ret.replace(/filters":"/,'filters":');
-                            ret=ret.replace("/}]}"/,'}]}');
+                            ret=ret.replace(/}]}"/,'}]}');
                         }
                         break;
                     case 'csvstring':

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -5340,7 +5340,70 @@ var xmlJsonClass = {
 		}
 		return e;
 	}
-};/*
+};
+
+var csvClass = {
+    toCsv: function (o, separator, hideColumns) {
+        // Param "o": Javascript Object.
+        // Param "separator": String that will be used to separate columns.
+        // Param "hideColumns": Columns that will be hidden.
+        // Returns:     CSV string
+
+        var csv = "";
+
+        csv += this.createHeaderCSV(o, separator, hideColumns);
+        csv += this.createDataCSV(o, separator, hideColumns);
+
+        return csv;
+    },
+    
+    // private members
+    shouldShowColumn: function(colModel, hideColumns) {
+        return !colModel.hidden && hideColumns.indexOf(colModel.name) == -1;
+    },
+    
+    createHeaderCSV: function(o, separator, hideColumns) {
+        var colNames = o.colNames;
+        var colModel = o.colModel;
+        
+        var line = "";
+        
+        for (var i = 0; i < colModel.length; i++) {
+            if (this.shouldShowColumn(colModel[i], hideColumns)) {
+                line += colNames[i] + separator;
+            }
+        }
+
+        line = line.slice(0, -1);
+
+        return line + '\r\n';
+    },
+    
+    createDataCSV: function (o, separator, hideColumns) {
+        var data = o.data;
+        var colModel = o.colModel;
+        
+        var lines = "";
+        var line = "";
+
+        for (var i = 0; i < data.length; i++) {
+            line = '';
+
+            for (var j = 0; j < colModel.length; j++) {
+                if (this.shouldShowColumn(colModel[j], hideColumns)) {
+                    line += data[i][colModel[j].name] + separator;
+                }
+            }
+
+            line = line.slice(0, -1);
+            lines += line + '\r\n';
+        }
+
+        return lines;
+    }
+};
+
+/*
 **
  * formatter for values but most of the values if for jqGrid
  * Some of this was inspired and based on how YUI does the table datagrid but in jQuery fashion
@@ -12104,9 +12167,11 @@ $.jgrid.extend({
                         ret = "{"+ xmlJsonClass.toJson(gprm,o.root,o.ident,false)+"}";
                         if(gprm.postData.filters !== undefined) {
                             ret=ret.replace(/filters":"/,'filters":');
-                            ret=ret.replace(/}]}"/,'}]}');
+                            ret=ret.replace("/}]}"/,'}]}');
                         }
                         break;
+                    case 'csvstring':
+                        ret = csvClass.toCsv(gprm, o.separator, o.hideColumns);    
                 }
             });
             return ret;


### PR DESCRIPTION
My previous commit in a better organized way - https://github.com/tonytomov/jqGrid/pull/476

I extended the jqGridExport method to allow CSV exporting.

You have 2 extra parameters:

hideColumns: [];
You will use it to choose columns that wont be exported. You have to use colModel.name.

separator: ";";
Choose the separator.

You can use it in this way:

var csv = $("#myGrid").jqGridExport({
                exptype: "csvstring",
                hideColumns: ["Cod"],
                separator: ";"
            });
