### PR TITLE
build.gradle - actual distribution file should not be included when buil...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ task init() {
 
 task jqgrid(dependsOn: 'init') {
     description = "Concatinate all javascript files into one javascript file: $jqGridFile.absolutePath"
-    def files = fileTree(dir: srcdir, include: '*.js')
+    def files = fileTree(dir: srcdir, include: '*.js', exclude: 'jquery.jqGrid.js')
     inputs.file files
     outputs.file jqGridFile
 


### PR DESCRIPTION
When building with gradle, the distribution file in the src folder should not be included or it will contained in the resulting build
