### PR TITLE
Dates of format n/j/Y were not parsed correctly for Filtering.

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -157,10 +157,13 @@ $.extend($.jgrid,{
 					}
 				}
 				if(ts.f) {ts.m = ts.f;}
+				if(ts.n) {ts.m = ts.n;}				
 				if( ts.m === 0 && ts.y === 0 && ts.d === 0) {
 					return "&#160;" ;
 				}
 				ts.m = parseInt(ts.m,10)-1;
+				if(ts.j) {ts.d = ts.j;}
+				ts.d = parseInt(ts.d,10);
 				var ty = ts.y;
 				if (ty >= 70 && ty <= 99) {ts.y = 1900+ts.y;}
 				else if (ty >=0 && ty <=69) {ts.y= 2000+ts.y;}


### PR DESCRIPTION
The parseDate function did not handle the 'n' and 'j' values for parsing a date of format n/j/Y that is the default short format for english dates in gird.locale-en.js