### PR TITLE
Merge parameters to a new object

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2937,7 +2937,11 @@ $.jgrid.extend({
 	},
 	setGridParam : function (newParams){
 		return this.each(function(){
-			if (this.grid && typeof newParams === 'object') {$.extend(true,this.p,newParams);}
+			if (this.grid && typeof newParams === 'object') {
+				var params = $.extend({}, this.p, newParams);
+				
+				this.p = params;
+			}
 		});
 	},
 	getGridRowById: function ( rowid ) {


### PR DESCRIPTION
**Description**
- Merge new parameters to a new object always overwriting the previous data.

**Why**:
- Imagine the situation where you need to reload the grid using different filters,
  merging into the first object (this.p), you are always appending data to the class parameters instead of overwrite them

**Bug sample**:

``` javascript
this.p = {'postData': {'arguments': {'filter': {'username': 'john' }}}};
```

Once you call setGridParam again trying to "change" a parameter, in this case, filter, your object will be:

``` javascript
this.p = {'postData': {'arguments': {'filter': {'username': 'john', 'lastname': 'maria' }}}};
```

And if you call it again you still "appending" data to the same configuration attribute, you will never be able to have the filter on its default state ( **_{}**_ )

**Solution**:
- Always overwrite the data

**Sample**:

``` javascript
this.p = {'postData': {'arguments': {'filter': {'username': 'john' }}}};
```

If you call the method, you should have:

``` javascript
this.p = {'postData': {'arguments': {'filter': {'lastname': 'maria' }}}};
```

This way, the user will be free to use whatever filter he wants... if he wants _first_ and _last_ name, just need to set a filter with both data.

``` javascript
this.p = {'postData': {'arguments': {'filter': {'username': 'john', 'lastname': 'maria' }}}};
```
