### PR TITLE
Fixing html encoding

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -3570,9 +3570,9 @@ $.jgrid.extend({
 						v = $t.formatter(rowid, nData, pos,ind,'edit');
 						title = $t.p.colModel[pos].title ? {"title":$.jgrid.stripHtml(v)} : {};
 						if($t.p.treeGrid && $(".tree-wrap",$(tcell)).length>0) {
-							$("span",$(tcell)).html(v).attr(title);
+							$("span",$(tcell)).text(v).attr(title);
 						} else {
-							$(tcell).html(v).attr(title);
+							$(tcell).text(v).attr(title);
 						}
 						if($t.p.datatype === "local") {
 							var cm = $t.p.colModel[pos], index;


### PR DESCRIPTION
When editing uses the setCell method we now set the value into the grid using 'text' rather than 'html' as otherwise if you enter something like &gt; in the edit textbox it is displayed in the grid as > rather than literally as &gt;
