### PR TITLE
Fixed bug related to custom element not appearing on search filter

### DIFF
--- a/js/grid.custom.js
+++ b/js/grid.custom.js
@@ -562,7 +562,7 @@ $.jgrid.extend({
 								var celm = soptions.custom_element.call($t,soptions.defaultValue !== undefined ? soptions.defaultValue: "",soptions);
 								if(celm) {
 									celm = $(celm).addClass("customelement");
-									$(thd).find(">span").append(celm);
+									$(thd).find("span[name='" + (cm.index || cm.name) + "']").append(celm);
 								} else {
 									throw "e2";
 								}

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -4447,7 +4447,7 @@ $.jgrid.extend({
 								var celm = soptions.custom_element.call($t,soptions.defaultValue !== undefined ? soptions.defaultValue: "",soptions);
 								if(celm) {
 									celm = $(celm).addClass("customelement");
-									$(thd).find(">span").append(celm);
+									$(thd).find("span[name='" + (cm.index || cm.name) + "']").append(celm);
 								} else {
 									throw "e2";
 								}


### PR DESCRIPTION
$(thd).find(">span").append(celm); never worked because $(thd).find(">span") never returned anything because the < span > element is never a direct child of the < table > element
