### PR TITLE
allow to set focus on select, textarea and button elements

### DIFF
--- a/js/grid.inlinedit.js
+++ b/js/grid.inlinedit.js
@@ -102,7 +102,7 @@ $.jgrid.extend({
 							focus = o.focusField;
 						}
 						setTimeout(function(){ 
-							var fe = $("td:eq("+focus+") input",ind).not(":disabled"); 
+							var fe = $("td:eq("+focus+") :input:visible",ind).not(":disabled"); 
 							if(fe.length > 0) {
 								fe.focus();
 							}


### PR DESCRIPTION
I suggest to use the same `:input:visible` pseudo-selector like in other parts of jqGrid code.
