### PR TITLE
Column resize indicator is misaligned when the grid is too big so that you have bowser horizontal scroll

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -880,17 +880,17 @@ $.fn.jqGrid = function( pin ) {
 			footers: [],
 			dragStart: function(i,x,y) {
 				var gridLeftPos = $(this.bDiv).offset().left;
-				this.resizing = { idx: i, startX: x.clientX, sOL : x.clientX - gridLeftPos };
+				this.resizing = { idx: i, startX: x.pageX, sOL : x.pageX - gridLeftPos };
 				this.hDiv.style.cursor = "col-resize";
 				this.curGbox = $("#rs_m"+$.jgrid.jqID(p.id),"#gbox_"+$.jgrid.jqID(p.id));
-				this.curGbox.css({display:"block",left:x.clientX-gridLeftPos,top:y[1],height:y[2]});
+				this.curGbox.css({display:"block",left:x.pageX-gridLeftPos,top:y[1],height:y[2]});
 				$(ts).triggerHandler("jqGridResizeStart", [x, i]);
 				if($.isFunction(p.resizeStart)) { p.resizeStart.call(ts,x,i); }
 				document.onselectstart=function(){return false;};
 			},
 			dragMove: function(x) {
 				if(this.resizing) {
-					var diff = x.clientX-this.resizing.startX,
+					var diff = x.pageX-this.resizing.startX,
 					h = this.headers[this.resizing.idx],
 					newWidth = p.direction === "ltr" ? h.width + diff : h.width - diff, hn, nWn;
 					if(newWidth > 33) {


### PR DESCRIPTION
Here is an example, http://jsbin.com/dopur/1/ (depending on the screen size you might not see the browser scroll bar, try resizing the grid until you do).

**Note**:
The grid is _**resized when you resize a column**_ so that the grids horizontal scrollbar is not shown. 

**Steps to reproduce using the above example**:
1. scroll the browser window to the right
2. try to resize a column from the far right, that is visible after scrolling
result: the resize indicator is misaligned 

**Problem**:
Looking in the code, i see that in grid.base.js for dragStart and dragStop functions, the event.clientX value is used to position the resize indicator, and since the grid is resized when a column is resized, the event.clientX is no longer valid since event.clientX is relative to the view port.

To fix my problem, the event.pageX should be used (in dradStart and dragMove), but i think this will make the column resize indicator misalign when using the gird horizontal scroll.

So any suggestions to hack this ?
Try to reposition the  resize indicator in resizeStart/resizeStop events?
