### PR TITLE
Update grid.base.js

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -3244,12 +3244,12 @@ $.jgrid.extend({
 		return success;
 	},
 	addRowData : function(rowid,rdata,pos,src) {
-		if(!pos) {pos = "last";}
+		if(["first", "last", "before", "after"].indexOf(pos) == -1) {pos = "last";}
 		var success = false, nm, row, gi, si, ni,sind, i, v, prp="", aradd, cnm, cn, data, cm, id;
 		if(rdata) {
 			if($.isArray(rdata)) {
 				aradd=true;
-				pos = "last";
+				//pos = "last";
 				cnm = rowid;
 			} else {
 				rdata = [rdata];


### PR DESCRIPTION
fixed: if the addRowData's rdata parameter is array and pos is 'after' or 'before', then can't work
