### PR TITLE
fixing exception at the end of sortableColumns

### DIFF
--- a/js/grid.jqueryui.js
+++ b/js/grid.jqueryui.js
@@ -112,7 +112,10 @@ $.jgrid.extend({
 			if (ts.p.sortable.exclude) {
 				sortable_opts.items += ":not("+ts.p.sortable.exclude+")";
 			}
-			tblrow.sortable(sortable_opts).data("sortable").floating = true;
+			var $e = tblrow.sortable(sortable_opts), dataObj = $e.data("sortable") || $e.data("uiSortable");
+			if (dataObj != null) {
+				dataObj.data("sortable").floating = true;
+			}
 		});
 	},
     columnChooser : function(opts) {


### PR DESCRIPTION
One need use `.data("uiSortable")` instead of `.data("sortable")` in the current version of jQuery UI. The current code produces exception during the attempt to assign `floating` property on `undefined` object.

The exception will be catches for example in [the line](https://github.com/tonytomov/jqGrid/blob/v4.6.0/js/grid.base.js#L2661-L2663) of jqGrid code

```
try {
    $(ts).jqGrid("sortableColumns", thr);
} catch (e){}
```

but not in case of direct usage of `sortableColumns`. The method end always with exception and so the usage of `try {...} } catch (e){}` is really required in all usages of the current version of `sortableColumns` together with the current versions of jQuery UI.

The suggested fix should work on old and new versions of jQuery UI.
