### PR TITLE
Allow to define named templates

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2438,12 +2438,16 @@ $.fn.jqGrid = function( pin ) {
 				}
 			}
 			return ci;
-		};
+		},
+		colTemplate;
 		this.p.id = this.id;
 		if ($.inArray(ts.p.multikey,sortkeys) === -1 ) {ts.p.multikey = false;}
 		ts.p.keyName=false;
 		for (i=0; i<ts.p.colModel.length;i++) {
-			ts.p.colModel[i] = $.extend(true, {}, ts.p.cmTemplate, ts.p.colModel[i].template || {}, ts.p.colModel[i]);
+			colTemplate = typeof ts.p.colModel[i].template === "string" ?
+				($.jgrid.cmTemplate != null && typeof $.jgrid.cmTemplate[ts.p.colModel[i].template] === "object" ? $.jgrid.cmTemplate[ts.p.colModel[i].template]: {}) :
+				ts.p.colModel[i].template;
+			ts.p.colModel[i] = $.extend(true, {}, ts.p.cmTemplate, colTemplate || {}, ts.p.colModel[i]);
 			if (ts.p.keyName === false && ts.p.colModel[i].key===true) {
 				ts.p.keyName = ts.p.colModel[i].name;
 			}


### PR DESCRIPTION
Hello Tony,

If one loads `colModel` from the server it's very practical to have properties which can be represented in JSON. If one want to use `dataIni` or other callbacks (for jQuery UI Datepicker, select2 or other controls) one can't load such column definition via JSON. jqGrid contains already practical feature in formatters. Formatters allow to extent `$.fn.fmatter` and assign **string name** to custom formatter and extend `$.unformat` to register the corresponding unformatter. In the way one can easy extend the list of predefined formatters.

jqGrid supports `template` property of `colModel` starting from version 3.8.2, but the value have to be an object. I suggest to make small modification of the code to allow to use for example `template: "number"`. To define `number` template one need just define `$.jgrid.cmTemplate.number` using

```
$.extend($.jgrid, {
    cmTemplate: {
        number: {
            formatter: "number", align: "right", sorttype: "number", searchoptions: { sopt: ["eq", "ne", "lt", "le", "gt", "ge"] }
        }
    }
});
```

I think that such small change can makes long code which uses jqGrid more small and more easy to maintain.

[The demo](http://www.ok-soft-gmbh.com/jqGrid/templateAsString.htm) demonstrates the usage of jqGrid after applying of suggested pull request.

You can consider to define some standard templates for numbers, intergers and dates at the beginning of `grid.base.js`.

Best regards
Oleg
