### PR TITLE
Add option to the delRowData function to optionally turn updating of the pager off

### DIFF
--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -3141,7 +3141,7 @@ $.jgrid.extend({
 		});
 		return resall || res;
 	},
-	delRowData : function(rowid) {
+	delRowData : function(rowid, doPagerUpdate) {
 		var success = false, rowInd, ia;
 		this.each(function() {
 			var $t = this;
@@ -3150,7 +3150,7 @@ $.jgrid.extend({
 				$(rowInd).remove();
 				$t.p.records--;
 				$t.p.reccount--;
-				$t.updatepager(true,false);
+				if (doPagerUpdate !== false) {$t.updatepager(true,false);}
 				success=true;
 				if($t.p.multiselect) {
 					ia = $.inArray(rowid,$t.p.selarrrow);


### PR DESCRIPTION
In our use case we separately update the pager.
Also we were noticing that on update after deleting a row the grid position was "jumping" a few rows (back to the last mouse-wheel scroll position ) 
This change fixed that bug for us.
