### PR TITLE
Allow setting arrays of arrays as searchoption

### DIFF
--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -4376,6 +4376,15 @@ $.jgrid.extend({
 										ov.value = sv[0]; ov.innerHTML = sv[1];
 										elem.appendChild(ov);
 									}
+								} else if (Object.prototype.toString.call(oSv) === "[object Array]") {
+									// array of arrays
+									for (var i=0; i<oSv.length; i++) {
+										if(oSv[i].length === 2) {
+											ov = document.createElement("option");
+											ov.value = oSv[i][0]; ov.innerHTML = oSv[i][1];
+											elem.appendChild(ov);
+										}
+									}
 								} else if(typeof oSv === "object" ) {
 									for (key in oSv) {
 										if(oSv.hasOwnProperty(key)) {


### PR DESCRIPTION
**The Issue:**
Currently there is no way to set an ordered list of elements as searchoptions for searchtype select.

**Justification for this PR:**
Currently there are two(three) different ways to set the elements as searchoptions.
- String, has delimiters and is inefficient for large lists.
- Object, ordering is browser (version) dependent, newer browsers sort the objects elements by key, (for faster access) which makes it almost impossible to sort them by value and still keep the entries id/key usefull.
- External, lot of overhead especially for small lists

**PR Breakdown:**
This PR allows the user of jqGrid to provide their searchoptions values as array[0-n] of arrays[2].

``` javascript
{name:'AnswersToQuestion42', index:'columnq42', width:60, search:true, stype:'select', searchoptions:{value: [[1,"Truth"], [2, "Power"], [3, "Relyability"]] } },
```

Each entry in the main array is its own entry in the dropdown box, the elements will not be sorted after being submited to jqGrid, browsers won't sort the list either.
The first element in each entry is the key, which is used/send internally for the filtering like the other ways do, the second entry is the value as shown to the user.
