### PR TITLE
Allow setting arrays of arrays as searchoption

### DIFF
--- a/js/grid.common.js
+++ b/js/grid.common.js
@@ -436,6 +436,20 @@ $.extend($.jgrid,{
 							if (!msl &&  ($.trim(sv[0]) === $.trim(vl) || $.trim(sv[1]) === $.trim(vl))) { ov.selected ="selected"; }
 							if (msl && ($.inArray($.trim(sv[1]), ovm)>-1 || $.inArray($.trim(sv[0]), ovm)>-1)) {ov.selected ="selected";}
 						}
+					} else if (Object.prototype.toString.call(options.value) === "[object Array]") {
+						var oSv = options.value;
+						// array of arrays [[Key, Value], [Key, Value], ...]
+						for (var i=0; i<oSv.length; i++) {
+							if(oSv[i].length === 2) {
+								var key = oSv[i][0], value = oSv[i][1];
+								ov = document.createElement("option");
+								ov.setAttribute("role","option");
+								ov.value = key; ov.innerHTML = value;
+								elem.appendChild(ov);
+								if (!msl &&  ( $.trim(key) === $.trim(vl) || $.trim(value) === $.trim(vl)) ) { ov.selected ="selected"; }
+								if (msl && ($.inArray($.trim(value),ovm)>-1 || $.inArray($.trim(key),ovm)>-1)) { ov.selected ="selected"; }
+							}
+						}
 					} else if (typeof options.value === 'object') {
 						var oSv = options.value, key;
 						for (key in oSv) {


### PR DESCRIPTION
**The Issue:**
Currently there is no way to set an ordered list of elements as searchoptions for searchtype select.

**Justification for this PR:**
Currently there are two(three) different ways to set the elements as searchoptions.
* String, has delimiters and is inefficient for large lists.
* Object, ordering is browser (version) dependent, newer browsers sort the objects elements by key, (for faster access) which makes it almost impossible to sort them by value and still keep the entries id/key usefull.
* External, lot of overhead especially for small lists

**PR Breakdown:**
This PR allows the user of jqGrid to provide their searchoptions values as array[0-n] of arrays[2].
````javascript
{name:'AnswersToQuestion42', index:'columnq42', width:60, search:true, stype:'select', searchoptions:{value: [[1,"Truth"], [2, "Power"], [3, "Relyability"]] } },
````
Each entry in the main array is its own entry in the dropdown box, the elements will not be sorted after being submited to jqGrid, browsers won't sort the list either.
The first element in each entry is the key, which is used/send internally for the filtering like the other ways do, the second entry is the value as shown to the user.

**Previous PR:**
https://github.com/tonytomov/jqGrid/pull/640