### PR TITLE
Update to the latest version of closure-compiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    jscompiler 'com.google.javascript:closure-compiler:v20141023'
+    jscompiler 'com.google.javascript:closure-compiler:v20141120'
 }
 
 def srcdir = new File('js')


### PR DESCRIPTION
Hi Tony,

New version v20141120 of closure-compiler are published after my last pull request (see [here](http://mvnrepository.com/artifact/com.google.javascript/closure-compiler/v20141120)). I think that it's better to use the latest version of the closure compiler for the next release of jqGrid.

Best regards
Oleg
