### PR TITLE
Fixed sortable rows for grid with grids expandable rows

### DIFF
--- a/js/grid.jqueryui.js
+++ b/js/grid.jqueryui.js
@@ -328,7 +328,7 @@ $.jgrid.extend({
 				opts = $.extend({
 					"cursor":"move",
 					"axis" : "y",
-					"items": ".jqgrow"
+					"items": " > .jqgrow"
 					},
 				opts || {});
 				if(opts.start && $.isFunction(opts.start)) {


### PR DESCRIPTION
An issue appears when there is one more grid inside expandable area. In that case the user have ability to drag a row from inner grid to main one.
