### PR TITLE
Limited call disableSelection to sortable rows only

### DIFF
--- a/js/grid.jqueryui.js
+++ b/js/grid.jqueryui.js
@@ -366,7 +366,7 @@ $.jgrid.extend({
 					}
 				};
 				$("tbody:first",$t).sortable(opts);
-				$("tbody:first",$t).disableSelection();
+				$("tbody:first > .jqgrow",$t).disableSelection();
 			}
 		});
 	},


### PR DESCRIPTION
Fixed focusing on inputs inside expandable sortable row in Firefox
