### PR TITLE
Fix scrollbar height issue in frozen columns

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -3925,7 +3925,7 @@ $.jgrid.extend({
 			bDiv.css({height: nh+(isNaN(nh)?"":"px")});
 			if($t.p.frozenColumns === true){
 				//follow the original set height to use 16, better scrollbar width detection
-				$('#'+$.jgrid.jqID($t.p.id)+"_frozen").parent().height(bDiv.height() - 16);
+				$('#'+$.jgrid.jqID($t.p.id)+"_frozen").parent().height(bDiv.height());
 			}
 			$t.p.height = nh;
 			if ($t.p.scroll) { $t.grid.populateVisible(); }
@@ -4479,7 +4479,7 @@ $.jgrid.extend({
 				}
 				$($t).bind('jqGridAfterGridComplete.setFrozenColumns', function () {
 					$("#"+$.jgrid.jqID($t.p.id)+"_frozen").remove();
-					$($t.grid.fbDiv).height($($t.grid.bDiv).height()-16);
+					$($t.grid.fbDiv).height($($t.grid.bDiv).height());
 					var btbl = $("#"+$.jgrid.jqID($t.p.id)).clone(true);
 					$("tr[role=row]",btbl).each(function(){
 						$("td[role=gridcell]:gt("+maxfrozen+")",this).remove();


### PR DESCRIPTION
Causing strange behavior in some browsers and is not necessary.

Mac OSX 10.10.3
Chrome 42.0.2311.135 (64-bit)
![screenshot 2015-05-12 10 35 56](https://cloud.githubusercontent.com/assets/3143166/7589825/0fa55880-f893-11e4-9b41-9700606d5772.png)
