### PR TITLE
Fix: Cannot read property append of undefined.

### DIFF
--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -1892,7 +1892,7 @@ $.fn.jqGrid = function( pin ) {
 					$(ts.rows[fpos]).after(rowData.join(''));
 				} else {
 					//$("tbody:first",t).append(rowData.join(''));
-					tablebody.append(rowData.join(''));
+					if(typeof tablebody != 'undefined') tablebody.append(rowData.join(''));
 					ts.grid.cols = ts.rows[0].cells; // update cached first row
 				}
 			}


### PR DESCRIPTION
Latest Chrome and Firefox (other browser not tested) get exception when no data load:
```
Uncaught TypeError: Cannot read property 'append' of undefined.
```