### PR TITLE
Browser Search on Header leads to misalignment

### DIFF
--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -1451,6 +1451,9 @@ $.fn.jqGrid = function( pin ) {
 				}
 				if( e ) { e.stopPropagation(); }
 			},
+			scrollHeaderGrid: function(e) {
+				grid.bDiv.scrollLeft = grid.hDiv.scrollLeft;
+			},
 			selectionPreserver : function(ts) {
 				var p = ts.p,
 				sr = p.selrow, sra = p.selarrrow ? $.makeArray(p.selarrrow) : null,
@@ -3298,7 +3301,7 @@ $.fn.jqGrid = function( pin ) {
 		grid.hDiv.style.width = (grid.width) + "px";
 		grid.hDiv.className = getstyle(stylemodule,'headerDiv', true,'ui-jqgrid-hdiv');
 
-		$(grid.hDiv).append(hb);
+		$(grid.hDiv).append(hb).scroll(grid.scrollHeaderGrid);
 		$(hb).append(hTable);
 		hTable = null;
 		if(hg) { $(grid.hDiv).hide(); }


### PR DESCRIPTION
If a search is performed on any text in the table header, which is
hidden because of overflow, then the table gets misaligned. It is the
browser's tendency to navigate to the found text and show it in the view
port. Since there is an overflow-x assigned to the header, the browser
assumes that to be a scrollable region and scrolls it when it finds a
match in the hidden cells. There is actually a scroll event triggered
when the body is scrolled to set the scroll left of body to the header
so that the header and the body remains in tact. But in this scenario
where user can search for text which are hidden on the header, the
scroll event for header is not delegated to adjust the body's scrollLeft
property.
