### PR TITLE
Fix error on row click event using recent jquery version

### DIFF
--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -3325,7 +3325,7 @@ $.fn.jqGrid = function( pin ) {
 		$(ts).before(grid.hDiv).click(function(e) {
 			td = e.target;
 			ptr = $(td,ts.rows).closest("tr.jqgrow");
-			if($(ptr).length === 0 || ptr[0].className.indexOf( disabled ) > -1 || ($(td,ts).closest("table.ui-jqgrid-btable").attr('id') || '').replace("_frozen","") !== ts.id ) {
+			if($(ptr).length === 0 || ptr[0].className.indexOf( disabled ) > -1 || ($(td,ts).closest("table.ui-jqgrid-btable")[0].id || '').replace("_frozen","") !== ts.id ) {
 				return this;
 			}
 			var scb = $(td).hasClass("cbox"),


### PR DESCRIPTION
With a recent version of jquery, we get a error
'Uncaught TypeError: ($(...).closest(...).attr(...) || "").replace is not a function'
when the user click in a row.

Looking at the code, can be easily solved replacing:

$(td,ts).closest("table.ui-jqgrid-btable").attr('id')

by

$(td,ts).closest("table.ui-jqgrid-btable")[0].id
