### PR TITLE
Fix in $.fn.fmatter.rowactions, to avoid copying sub-objects of cm.fo…

### DIFF
--- a/js/jquery.fmatter.js
+++ b/js/jquery.fmatter.js
@@ -290,7 +290,10 @@
 			};
 
 		if (cm.formatoptions !== undefined) {
-			op = $.extend(op,cm.formatoptions);
+			// Deep clone before copying over to op, to avoid creating unintentional references.
+			// Otherwise, the assignment of op.extraparam[p.prmNames.oper] below may persist into the colModel config.
+			var formatoptionsClone = $.extend(true, {}, cm.formatoptions);
+			op = $.extend(op, formatoptionsClone);
 		}
 		if (p.editOptions !== undefined) {
 			op.editOptions = p.editOptions;


### PR DESCRIPTION
…rmatoptions by reference

This fixes a bug where if you add rows using $.jgrid.addRow(), and you have a column
with 'actions' formatter, and you click the edit button in the actions column, the
'oper' param of the AJAX request for saving the edit will still be 'add'. This happened
because cm.formatoptions.extraparams passed by reference into 'op', and then oper=add
was set to it. Now it is no longer passed by reference, due to using deep clone first.
