### PR TITLE
Fix: colMenu sorting was not working properly with multiSort: true

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2802,25 +2802,31 @@ $.fn.jqGrid = function( pin ) {
 				});
 			}
 		},
-		multiSort = function(iCol, obj ) {
+		multiSort = function(iCol, obj, sor ) {
 			var cm = ts.p.colModel,
 					selTh = ts.p.frozenColumns ?  obj : ts.grid.headers[iCol].el, so="", sn;
 			$("span.ui-grid-ico-sort",selTh).addClass(disabled);
 			$(selTh).attr("aria-selected","false");
 			sn = (cm[iCol].index || cm[iCol].name);
-			if(cm[iCol].lso) {
-				if(cm[iCol].lso==="asc") {
-					cm[iCol].lso += "-desc";
-					so = "desc";
-				} else if(cm[iCol].lso==="desc") {
-					cm[iCol].lso += "-asc";
-					so = "asc";
-				} else if(cm[iCol].lso==="asc-desc" || cm[iCol].lso==="desc-asc") {
-					cm[iCol].lso="";
+			if ( typeof sor == "undefined" )
+			{
+				if(cm[iCol].lso) {
+					if(cm[iCol].lso==="asc") {
+						cm[iCol].lso += "-desc";
+						so = "desc";
+					} else if(cm[iCol].lso==="desc") {
+						cm[iCol].lso += "-asc";
+						so = "asc";
+					} else if(cm[iCol].lso==="asc-desc" || cm[iCol].lso==="desc-asc") {
+						cm[iCol].lso="";
+					}
+				} else {
+					cm[iCol].lso = so = cm[iCol].firstsortorder || 'asc';
 				}
-			} else {
-				cm[iCol].lso = so = cm[iCol].firstsortorder || 'asc';
 			}
+			else {
+				cm[iCol].lso = so = sor;
+			}	
 			if( so ) {
 				$("span.s-ico",selTh).show();
 				$("span.ui-icon-"+so,selTh).removeClass(disabled);
@@ -2884,7 +2890,7 @@ $.fn.jqGrid = function( pin ) {
 				ts.p.page = 1;
 			}
 			if(ts.p.multiSort) {
-				multiSort( idxcol, obj);
+				multiSort( idxcol, obj, sor);
 			} else {
 				if(sor) {
 					if(ts.p.lastsort === idxcol && ts.p.sortorder === sor && !reload) { return; }

--- a/js/i18n/grid.locale-fr.js
+++ b/js/i18n/grid.locale-fr.js
@@ -163,8 +163,8 @@ $.jgrid.regional["fr"] = {
 		idName : 'id'
 	},
 	colmenu : {
-		sortasc : "Trier en ordre ascendant",
-		sortdesc: "Trier en ordre descendant",
+		sortasc : "Trier en ordre croissant",
+		sortdesc: "Trier en ordre décroissant",
 		columns : "Colonnes",
 		filter : "Filtrer",
 		grouping : "Grouper par",

--- a/js/i18n/grid.locale-fr.js
+++ b/js/i18n/grid.locale-fr.js
@@ -37,7 +37,7 @@ $.jgrid.regional["fr"] = {
 		pgnext : "Page suivante",
 		pgprev : "Page précédente",
 		pgrecs : "Enregistrements par page",
-		showhide: "Réduire/Agrandire la grille",
+		showhide: "Réduire/Agrandir la grille",
 		// mobile
 		pagerCaption : "Grille::Options de pagination",
 		pageText : "Page:",


### PR DESCRIPTION
Using the column menu sorting with multiSort: true on the grid resulted in a toggle from asc to desc to not ordered instead of following what the user clicked on. I have modified the multiSort function to include a "sor" parameter that will dictate the sort order if it is provided, instead of causing the regular toggle. 

Included in this commit is also an additional french language fix that was pointed out by one of my coworkers.