### PR TITLE
Fixed misspelling of "inline-block"

### DIFF
--- a/css/ui.jqgrid-bootstrap.css
+++ b/css/ui.jqgrid-bootstrap.css
@@ -887,7 +887,7 @@ ul.ui-search-menu li, ul.ui-nav-menu li {
 .ui-jqgrid .ui-jqgrid-htable .ui-th-div {
 	height:17px;
 	margin-top:5px;
-	display:inine-block;
+	display:inline-block;
 }
 .column-menu, .ui-search-menu {
 	padding: 10px 15px;


### PR DESCRIPTION
The display attribute was "inine-block," which is invalid CSS. Corrected the typo to "inline-block."