### PR TITLE
Solve problems with same ids of grid

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2034,7 +2034,7 @@ $.fn.jqGrid = function( pin ) {
 				selected = true;
 			}
 			var afterInsRow = $.isFunction(ts.p.afterInsertRow), grpdata=[],hiderow=false, groupingPrepare,
-			tablebody = $("#"+$.jgrid.jqID(ts.p.id)+" tbody:first"),
+			tablebody = $("tbody:first", ts),
 			rnc = ni ? getstyle(stylemodule, 'rownumBox', false, 'jqgrid-rownum') :"",
 			mlc = gi ? getstyle(stylemodule, 'multiBox', false, 'cbox'):"";
 			if(ts.p.grouping)  {


### PR DESCRIPTION
I do not understand...
Why u use selection by id when u already have table element?!

How i see there is many uses of $.jgrid.jqID
They must be all checked for using ts element for $ selection