### PR TITLE
Add a showSaveCancelButtons()

### DIFF
--- a/js/grid.inlinedit.js
+++ b/js/grid.inlinedit.js
@@ -716,6 +716,17 @@ $.jgrid.extend({
 			$("#"+gID+"_iladd").removeClass( disabled );
 			$("#"+gID+"_iledit").removeClass( disabled );
 		});
+	},
+	showSaveCancelButtons : function()  {
+		return this.each(function(){
+			if (!this.grid ) { return; }
+			var gID = $.jgrid.jqID(this.p.id),
+			disabled = $.trim( $(this).jqGrid('getStyleUI', this.p.styleUI+'.common', 'disabled', true) );
+			$("#"+gID+"_ilsave").removeClass( disabled );
+			$("#"+gID+"_ilcancel").removeClass( disabled );
+			$("#"+gID+"_iladd").addClass( disabled );
+			$("#"+gID+"_iledit").addClass( disabled );
+		});
 	}
 //end inline edit
 });


### PR DESCRIPTION
Add a showSaveCancelButtons() like showAddEditButtons(). When I double click row and call editRow(), then need showSaveCancelButtons() to enable the save and cancel buttons.