### PR TITLE
Fix dirty-cell not being set and console error when saving using latest jQuery

### DIFF
--- a/js/grid.celledit.js
+++ b/js/grid.celledit.js
@@ -286,6 +286,7 @@ $.jgrid.extend({
 												}
 												$(cc).empty();
 												$($t).jqGrid("setCell",$t.p.savedRow[fr].rowId, iCol, v2, false, false, true);
+												cc = $('td:eq('+iCol+')', trow);
 												$(cc).addClass("dirty-cell");
 												$(trow).addClass("edited");
 												$($t).triggerHandler("jqGridAfterSaveCell", [$t.p.savedRow[fr].rowId, nm, v, iRow, iCol]);
@@ -350,6 +351,7 @@ $.jgrid.extend({
 						if ($t.p.cellsubmit === 'clientArray') {
 							$(cc).empty();
 							$($t).jqGrid("setCell", $t.p.savedRow[fr].rowId, iCol, v2, false, false, true);
+							cc = $('td:eq('+iCol+')', trow);
 							$(cc).addClass("dirty-cell");
 							$(trow).addClass("edited");
 							$($t).triggerHandler("jqGridAfterSaveCell", [$t.p.savedRow[fr].rowId, nm, v, iRow, iCol]);

--- a/js/grid.formedit.js
+++ b/js/grid.formedit.js
@@ -603,7 +603,7 @@ $.jgrid.extend({
 									}
 									if(rp_ge[$t.p.id].closeAfterEdit) {$.jgrid.hideModal("#"+$.jgrid.jqID(IDs.themodal),{gb:"#gbox_"+$.jgrid.jqID(gID),jqm:p.jqModal,onClose: rp_ge[$t.p.id].onClose, removemodal: rp_ge[$t.p.id].removemodal, formprop: !rp_ge[$t.p.id].recreateForm, form: rp_ge[$t.p.id].form});}
 								}
-								if( $.isFunction(rp_ge[$t.p.id].afterComplete) || $._data( $($t)[0], 'events' ).hasOwnProperty('jqGridAddEditAfterComplete') ) {
+								if( $.isFunction(rp_ge[$t.p.id].afterComplete) || Object.prototype.hasOwnProperty.call($._data( $($t)[0], 'events' ), 'jqGridAddEditAfterComplete') ) {
 									copydata = data;
 									setTimeout(function(){
 										$($t).triggerHandler("jqGridAddEditAfterComplete", [copydata, postdata, $(frmgr), frmoper]);
@@ -1642,7 +1642,7 @@ $.jgrid.extend({
 										$t.p.selrow = null;
 										$t.p.selarrrow = [];
 									}
-									if($.isFunction(rp_ge[$t.p.id].afterComplete) || $._data( $($t)[0], 'events' ).hasOwnProperty('jqGridDelRowAfterComplete')) {
+									if($.isFunction(rp_ge[$t.p.id].afterComplete) || Object.prototype.hasOwnProperty.call($._data( $($t)[0], 'events' ), 'jqGridDelRowAfterComplete')) {
 										var copydata = data;
 										setTimeout(function(){
 											$($t).triggerHandler("jqGridDelRowAfterComplete", [copydata, postd]);


### PR DESCRIPTION
### Fixes for the following two bugs:

**Dirty-cell not being set on cells changed inline, causing getChangedCells to not return data other than row ids.**
- jqGrid "setCell" method replaces the entire td element with a new one, so when jqGrid calls addClass("dirty-cell") it is executed on the old jquery td element "cc", that element no longer exists in the dom, so the "dirty-cell" class isn't added to the new cell.
- jqGrid needs to update "cc" variable when replacing the td element, so that the new cell is marked as dirty when addClass is called.

**Getting console error "hasOwnProperty is not a function" when saving data from an edit form using the latest jQuery**
- The new jQuery (3.5.1) creates "events" data as a null prototype object, but jqGrid is expecting it to be a normal object and is attempting to call its "hasOwnProperty" function.
- Fixed by calling the hasOwnProperty function from the Object prototype.