### PR TITLE
Support objects on $.jgrid.template

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -80,6 +80,8 @@ $.extend($.jgrid,{
 							return nmarr[k].v;
 						}
 					}
+				} else if(typeof args[j] === 'object' && args[j][i]) {
+					return $.jgrid.isFunction(args[j][i]) ? args[j][i]() : args[j][i];
 				}
 			}
 		});

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -85,6 +85,8 @@ $.extend($.jgrid,{
 							return nmarr[k].v;
 						}
 					}
+				} else if(typeof args[j] === 'object' && args[j][i]) {
+					return $.jgrid.isFunction(args[j][i]) ? args[j][i]() : args[j][i];
 				}
 			}
 		});


### PR DESCRIPTION
This allow us to do 
```js
$.jgrid.template(
    'START {0} {1} {test1} {test2} {test3} END',
    '000',
    '111',
    { test1: 'A' },
    { test3: () => 'C',  test2: 'B' }
);
// result: 'START 000 111 A B C END'
```