### PR TITLE
Update `ES` language

### DIFF
--- a/js/i18n/grid.locale-es.js
+++ b/js/i18n/grid.locale-es.js
@@ -48,7 +48,12 @@ $.jgrid.regional["es"] = {
 		nomorerecs : "No más registros...",
 		scrollPullup: "Arrastrar arriba para cargar más...",
 		scrollPulldown : "Arrastrar arriba para refrescar...",
-		scrollRefresh : "Soltar para refrescar..."		
+		scrollRefresh : "Soltar para refrescar...",
+		valueCheckbox : "Checkbox",
+                valT : "marcada",
+                valF : "sin marcar",
+                selectLine : "Seleccionar fila",
+                selectAllLines : "Seleccionar todas las filas"
 	},
 	search : {
 	    caption: "Búsqueda...",
@@ -64,8 +69,8 @@ $.jgrid.regional["es"] = {
 		delrule : "Borrar regla",
 		Close : "Cerrar",
 		Operand : "Operador : ",
-		Operation : "Oper : "
-
+		Operation : "Oper : ",
+                filterFor : "filtro para"
 	},
 	edit : {
 	    addCaption: "Agregar registro",


### PR DESCRIPTION
Some missing keys are giving me exceptions 
https://github.com/tonytomov/jqGrid/commit/74b07491c33f625ba8b2691fb70e127377a754d6

```
Uncaught TypeError: Cannot read properties of undefined (reading 'defaults')
    at HTMLTableElement.<anonymous> (grid.base.js?x=4:1:97695)
    at Function.each (jquery.min.js:2:3129)
    at ce.fn.init.each (jquery.min.js:2:1594)
    at $e.fn.jqGrid (grid.base.js?x=4:1:40514)
```