### PR TITLE
add support for string functions

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -451,6 +451,19 @@ $.extend($.jgrid,{
 		$(div).remove();
 		return (w1 - w2) < 0 ? 18 : (w1 - w2);
 	},
+	executeEvent: function (func, args) {
+		if (typeof func === 'string') {
+			var onFncNameSpaces = func.split('.');
+			var onFunc = onFncNameSpaces.pop();
+			var onFuncContext = window;
+			for (var i = 0; i < onFncNameSpaces.length; i++) {
+				onFuncContext = onFuncContext[onFncNameSpaces[i]];
+			}
+			return onFuncContext[onFunc].apply(onFuncContext, args);
+		} else {
+			return func.call(...args);
+		}
+	},
 	ajaxOptions: {},
 	from : function(source){
 		// Original Author Hugo Bonacci

--- a/js/grid.common.js
+++ b/js/grid.common.js
@@ -30,7 +30,8 @@ $.extend($.jgrid,{
 		o = $.extend({jqm : true, gb :'', removemodal: false, formprop: false, form : ''}, o || {});
 		var thisgrid = o.gb && typeof o.gb === "string" && o.gb.slice(0,6) === "#gbox_" ? $("#" + o.gb.slice(6))[0] : false;
 		if(o.onClose) {
-			var oncret = thisgrid ? o.onClose.call(thisgrid, selector) : o.onClose(selector);
+			var args = thisgrid ? [thisgrid, selector] : [selector];
+			var oncret = $.jgrid.executeEvent(o.onClose, args);
 			if (typeof oncret === 'boolean'  && !oncret ) { return; }
 		}
 		if( o.formprop && thisgrid  && o.form) {

--- a/js/jquery.jqGrid.js
+++ b/js/jquery.jqGrid.js
@@ -456,6 +456,19 @@ $.extend($.jgrid,{
 		$(div).remove();
 		return (w1 - w2) < 0 ? 18 : (w1 - w2);
 	},
+	executeEvent: function (func, args) {
+		if (typeof func === 'string') {
+			var onFncNameSpaces = func.split('.');
+			var onFunc = onFncNameSpaces.pop();
+			var onFuncContext = window;
+			for (var i = 0; i < onFncNameSpaces.length; i++) {
+				onFuncContext = onFuncContext[onFncNameSpaces[i]];
+			}
+			return onFuncContext[onFunc].apply(onFuncContext, args);
+		} else {
+			return func.call(...args);
+		}
+	},
 	ajaxOptions: {},
 	from : function(source){
 		// Original Author Hugo Bonacci


### PR DESCRIPTION
Setting `onClose` within the `setNavOptions` in a PHP back end similar to:

```$grid_excs->setNavOptions('edit', array("closeAfterEdit" => true, "width" => 900, "height" => 500, "dataheight" => 400, "closeOnEscape" => false, "onClose" => "testClose"));```

... will result in PHP returning the function name as a string which will result in the error: `TypeError: o.onClose.call is not a function`

This update will parse that function name along with any namespace such as `MyApp.testClose`, execute it and return the result of the function.